### PR TITLE
Update website download and install video

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Core-Monitor</title>
-  <meta name="description" content="Core-Monitor is an open-source macOS control center with fan control, live monitoring, a Touch Bar HUD, and menu bar stats.">
+  <meta name="description" content="Core-Monitor is an open-source macOS control center with fan control, live monitoring, supported Touch Bar widgets, and menu bar stats.">
   <meta name="application-name" content="Core-Monitor">
   <meta name="apple-mobile-web-app-title" content="Core-Monitor">
   <meta name="theme-color" content="#0a0c16">
@@ -30,7 +30,7 @@
         <a href="#install">Install</a>
         <a href="#privacy">Privacy</a>
       </nav>
-      <a class="nav-download" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest</a>
+      <a class="nav-download" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest</a>
     </header>
 
     <main id="top">
@@ -57,10 +57,10 @@
         </figure>
         <div class="hero-copy hero-copy-secondary">
           <p class="hero-lead">
-            Live monitoring, real fan control, menu bar stats, benchmarking, and Touch Bar tools in one native app.
+            Live monitoring, real fan control, menu bar stats, benchmarking, and supported Touch Bar tools in one native app.
           </p>
           <div class="hero-actions">
-            <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+            <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
             <a class="button secondary" href="#screens">See the UI</a>
             <a class="button ghost" href="https://github.com/offyotto-sl3/Core-Monitor">View on GitHub</a>
           </div>
@@ -76,11 +76,11 @@
         <div class="install-grid">
           <article class="install-card install-card-main">
             <p class="card-step">1. Download</p>
-            <h3>Grab the latest signed build directly.</h3>
+            <h3>Grab the latest release from GitHub.</h3>
             <p>
-              The download button points straight at the newest published build, so you do not have to bounce through the GitHub release page first.
+              The download button opens the newest published GitHub release, so you can choose the current app archive.
             </p>
-            <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+            <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
           </article>
           <article class="install-card">
             <p class="card-step">2. First launch</p>
@@ -146,7 +146,7 @@
           </article>
           <article class="feature-card">
             <h3>Touch Bar HUD</h3>
-            <p>A persistent Touch Bar stats surface driven by reverse-engineered presentation behavior so the hardware stays useful beyond the foreground app.</p>
+            <p>A supported production Touch Bar surface for battery, power, and fan mode without private brightness, now-playing, or audio-control polling.</p>
           </article>
           <article class="feature-card">
             <h3>Menu bar utility</h3>
@@ -175,7 +175,7 @@
           </article>
           <article class="feature-card">
             <h3>No telemetry, no analytics, no data collection</h3>
-            <p>Core-Monitor does not ship with analytics, ad tech, or account-based tracking. The app runs locally on your Mac and focuses on hardware monitoring, fan control, Touch Bar tools, and menu bar stats without building a profile about you.</p>
+            <p>Core-Monitor does not ship with analytics, ad tech, or account-based tracking. The app runs locally on your Mac and focuses on hardware monitoring, fan control, supported Touch Bar tools, and menu bar stats without building a profile about you.</p>
           </article>
           <article class="feature-card">
             <h3>No subscription wall</h3>
@@ -236,7 +236,7 @@
           <h2>Download the newest release or inspect the full source.</h2>
         </div>
         <div class="cta-actions">
-          <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+          <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
           <a class="button ghost" href="https://github.com/offyotto-sl3/Core-Monitor">Browse Source on GitHub</a>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Core-Monitor</title>
-  <meta name="description" content="Core-Monitor is an open-source macOS control center with fan control, live monitoring, a Touch Bar HUD, and menu bar stats.">
+  <meta name="description" content="Core-Monitor is an open-source macOS control center with fan control, live monitoring, supported Touch Bar widgets, and menu bar stats.">
   <meta name="application-name" content="Core-Monitor">
   <meta name="apple-mobile-web-app-title" content="Core-Monitor">
   <meta name="theme-color" content="#0a0c16">
@@ -30,7 +30,7 @@
         <a href="#install">Install</a>
         <a href="#privacy">Privacy</a>
       </nav>
-      <a class="nav-download" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest</a>
+      <a class="nav-download" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest</a>
     </header>
 
     <main id="top">
@@ -57,10 +57,10 @@
         </figure>
         <div class="hero-copy hero-copy-secondary">
           <p class="hero-lead">
-            Live monitoring, real fan control, menu bar stats, benchmarking, and Touch Bar tools in one native app.
+            Live monitoring, real fan control, menu bar stats, benchmarking, and supported Touch Bar tools in one native app.
           </p>
           <div class="hero-actions">
-            <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+            <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
             <a class="button secondary" href="#screens">See the UI</a>
             <a class="button ghost" href="https://github.com/offyotto-sl3/Core-Monitor">View on GitHub</a>
           </div>
@@ -76,11 +76,11 @@
         <div class="install-grid">
           <article class="install-card install-card-main">
             <p class="card-step">1. Download</p>
-            <h3>Grab the latest signed build directly.</h3>
+            <h3>Grab the latest release from GitHub.</h3>
             <p>
-              The download button points straight at the newest published build, so you do not have to bounce through the GitHub release page first.
+              The download button opens the newest published GitHub release, so you can choose the current app archive.
             </p>
-            <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+            <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
           </article>
           <article class="install-card">
             <p class="card-step">2. First launch</p>
@@ -146,7 +146,7 @@
           </article>
           <article class="feature-card">
             <h3>Touch Bar HUD</h3>
-            <p>A persistent Touch Bar stats surface driven by reverse-engineered presentation behavior so the hardware stays useful beyond the foreground app.</p>
+            <p>A supported production Touch Bar surface for battery, power, and fan mode without private brightness, now-playing, or audio-control polling.</p>
           </article>
           <article class="feature-card">
             <h3>Menu bar utility</h3>
@@ -175,7 +175,7 @@
           </article>
           <article class="feature-card">
             <h3>No telemetry, no analytics, no data collection</h3>
-            <p>Core-Monitor does not ship with analytics, ad tech, or account-based tracking. The app runs locally on your Mac and focuses on hardware monitoring, fan control, Touch Bar tools, and menu bar stats without building a profile about you.</p>
+            <p>Core-Monitor does not ship with analytics, ad tech, or account-based tracking. The app runs locally on your Mac and focuses on hardware monitoring, fan control, supported Touch Bar tools, and menu bar stats without building a profile about you.</p>
           </article>
           <article class="feature-card">
             <h3>No subscription wall</h3>
@@ -236,7 +236,7 @@
           <h2>Download the newest release or inspect the full source.</h2>
         </div>
         <div class="cta-actions">
-          <a class="button primary" href="https://offyotto-sl3.github.io/Core-Monitor/downloads/Core-Monitor-11.2.10.zip">Download Latest Release</a>
+          <a class="button primary" href="https://github.com/offyotto-sl3/Core-Monitor/releases/latest">Download Latest Release</a>
           <a class="button ghost" href="https://github.com/offyotto-sl3/Core-Monitor">Browse Source on GitHub</a>
         </div>
       </section>


### PR DESCRIPTION
Updates the website download links to point to the latest GitHub release and replaces the install walkthrough video with the new recording.