### PR TITLE
Fix Xcode 16.2 CI compatibility

### DIFF
--- a/Core-Monitor/FanController.swift
+++ b/Core-Monitor/FanController.swift
@@ -4,7 +4,7 @@ import AppKit
 
 // MARK: - Fan Control Modes
 
-nonisolated enum FanControlMode: String, CaseIterable {
+enum FanControlMode: String, CaseIterable {
     case smart
     case silent
     case balanced
@@ -126,12 +126,12 @@ nonisolated enum FanControlMode: String, CaseIterable {
     }
 }
 
-nonisolated enum FanControlOwnership: Equatable {
+enum FanControlOwnership: Equatable {
     case system
     case coreMonitor
 }
 
-nonisolated struct FanModeGuidance: Equatable {
+struct FanModeGuidance: Equatable {
     let summary: String
     let detail: String
     let ownership: FanControlOwnership
@@ -142,8 +142,8 @@ nonisolated struct FanModeGuidance: Equatable {
 
 // MARK: - Custom Fan Preset Model
 
-nonisolated struct CustomFanPreset: Codable, Equatable {
-    nonisolated enum Sensor: String, Codable, CaseIterable, Identifiable {
+struct CustomFanPreset: Codable, Equatable {
+    enum Sensor: String, Codable, CaseIterable, Identifiable {
         case cpu
         case gpu
         case max
@@ -159,7 +159,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
         }
     }
 
-    nonisolated struct CurvePoint: Codable, Equatable, Identifiable {
+    struct CurvePoint: Codable, Equatable, Identifiable {
         let id: UUID
         var temperatureC: Double
         var speedPercent: Double
@@ -190,7 +190,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
         }
     }
 
-    nonisolated struct PowerBoost: Codable, Equatable {
+    struct PowerBoost: Codable, Equatable {
         var enabled: Bool = true
         var wattsAtMaxBoost: Double = 40
         var maxAddedTemperatureC: Double = 8
@@ -342,7 +342,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
     }
 }
 
-nonisolated enum CustomPresetSaveOutcome {
+enum CustomPresetSaveOutcome {
     case success(String)
     case failure([String])
 }

--- a/Core-Monitor/TopProcessSampler.swift
+++ b/Core-Monitor/TopProcessSampler.swift
@@ -2,7 +2,6 @@ import AppKit
 import Darwin
 import Foundation
 
-@MainActor
 final class TopProcessSampler {
     private struct SampledProcess {
         let pid: pid_t

--- a/Core-Monitor/TouchBarUtilityWidgets.swift
+++ b/Core-Monitor/TouchBarUtilityWidgets.swift
@@ -228,6 +228,7 @@ enum SystemBrightness {
 }
 
 @available(macOS 13.0, *)
+@MainActor
 final class ControlCenterSliderPresenter: NSObject, NSTouchBarDelegate {
     enum SliderKind {
         case brightness

--- a/Core-Monitor/WeatherService.swift
+++ b/Core-Monitor/WeatherService.swift
@@ -35,6 +35,7 @@ protocol WeatherProviding: AnyObject {
     func currentWeather(for location: CLLocation) async throws -> WeatherSnapshot
 }
 
+@MainActor
 protocol WeatherLocationAccessControlling: AnyObject {
     var authorizationStatus: CLAuthorizationStatus { get }
     var currentLocation: CLLocation? { get }
@@ -43,7 +44,7 @@ protocol WeatherLocationAccessControlling: AnyObject {
 }
 
 @MainActor
-final class WeatherLocationAccessController: NSObject, ObservableObject, CLLocationManagerDelegate, WeatherLocationAccessControlling {
+final class WeatherLocationAccessController: NSObject, ObservableObject, @preconcurrency CLLocationManagerDelegate, WeatherLocationAccessControlling {
     static let shared = WeatherLocationAccessController()
 
     @Published private(set) var authorizationStatus: CLAuthorizationStatus


### PR DESCRIPTION
## Summary
- remove the type-level `nonisolated` modifiers that Xcode 16.2 rejects in `FanController`
- avoid initializing `TopProcessSampler` from a main-actor-isolated type context that breaks the older CI compiler
- mark the control-center slider presenter and weather access protocol/conformance to align actor isolation with current usage

## Verification
- reproduced the current CI failure from Actions run `24490524665`
- ran `xcodebuild test -project Core-Monitor.xcodeproj -scheme Core-Monitor -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` locally on the patch branch

## Notes
- the local machine is on a newer Xcode than GitHub Actions, so the hosted CI rerun is the final confirmation for the Xcode 16.2 path