### PR TITLE
Fix monitoring model isolation for Xcode 16.2 CI

### DIFF
--- a/Core-Monitor/AlertEngine.swift
+++ b/Core-Monitor/AlertEngine.swift
@@ -29,7 +29,7 @@ struct AlertEvaluationOutcome {
 }
 
 enum AlertEvaluator {
-    nonisolated static func evaluate(
+    static func evaluate(
         config: AlertRuleConfig,
         runtime: AlertRuleRuntime,
         input: AlertEvaluationInput
@@ -210,7 +210,7 @@ enum AlertEvaluator {
         )
     }
 
-    nonisolated static func availabilityReason(
+    static func availabilityReason(
         for kind: AlertRuleKind,
         snapshot: SystemMonitorSnapshot
     ) -> String? {
@@ -230,7 +230,7 @@ enum AlertEvaluator {
         ).unavailableReason
     }
 
-    nonisolated private static func measurement(
+    private static func measurement(
         for kind: AlertRuleKind,
         config: AlertRuleConfig,
         input: AlertEvaluationInput,
@@ -494,7 +494,7 @@ enum AlertEvaluator {
         }
     }
 
-    nonisolated private static func unavailable(_ kind: AlertRuleKind, reason: String) -> AlertMeasurement {
+    private static func unavailable(_ kind: AlertRuleKind, reason: String) -> AlertMeasurement {
         AlertMeasurement(
             severity: .none,
             metricValue: nil,
@@ -506,7 +506,7 @@ enum AlertEvaluator {
         )
     }
 
-    nonisolated private static func makeActiveState(
+    private static func makeActiveState(
         kind: AlertRuleKind,
         severity: AlertSeverity,
         measurement: AlertMeasurement,
@@ -525,7 +525,7 @@ enum AlertEvaluator {
         )
     }
 
-    nonisolated private static func runtimeReset(from runtime: AlertRuleRuntime) -> AlertRuleRuntime {
+    private static func runtimeReset(from runtime: AlertRuleRuntime) -> AlertRuleRuntime {
         var nextRuntime = runtime
         nextRuntime.activeSeverity = .none
         nextRuntime.pendingSeverity = .none
@@ -535,7 +535,7 @@ enum AlertEvaluator {
         return nextRuntime
     }
 
-    nonisolated private static func shouldNotify(
+    private static func shouldNotify(
         config: AlertRuleConfig,
         runtime: AlertRuleRuntime,
         severity: AlertSeverity,
@@ -560,7 +560,7 @@ enum AlertEvaluator {
         }
     }
 
-    nonisolated private static func shouldRepeatEvent(
+    private static func shouldRepeatEvent(
         config: AlertRuleConfig,
         runtime: AlertRuleRuntime,
         input: AlertEvaluationInput
@@ -570,7 +570,7 @@ enum AlertEvaluator {
         return input.now.timeIntervalSince(lastEventDate) >= Double(config.cooldownMinutes * 60)
     }
 
-    nonisolated private static func severityForHighValue(
+    private static func severityForHighValue(
         _ value: Double,
         threshold: AlertThreshold,
         activeSeverity: AlertSeverity
@@ -597,7 +597,7 @@ enum AlertEvaluator {
         return .none
     }
 
-    nonisolated private static func severityForLowValue(
+    private static func severityForLowValue(
         _ value: Double,
         threshold: AlertThreshold,
         activeSeverity: AlertSeverity
@@ -624,19 +624,19 @@ enum AlertEvaluator {
         return .none
     }
 
-    nonisolated private static func topCPUContext(from topProcesses: TopProcessSnapshot, enabled: Bool) -> String? {
+    private static func topCPUContext(from topProcesses: TopProcessSnapshot, enabled: Bool) -> String? {
         guard enabled else { return nil }
         guard let process = topProcesses.topCPU.first, process.cpuPercent > 0 else { return nil }
         return String(format: "Top CPU: %@ (%.0f%%)", process.name, process.cpuPercent)
     }
 
-    nonisolated private static func topMemoryContext(from topProcesses: TopProcessSnapshot, enabled: Bool) -> String? {
+    private static func topMemoryContext(from topProcesses: TopProcessSnapshot, enabled: Bool) -> String? {
         guard enabled else { return nil }
         guard let process = topProcesses.topMemory.first, process.memoryBytes > 0 else { return nil }
         return String(format: "Top Memory: %@ (%.1f GB)", process.name, process.memoryGB)
     }
 
-    nonisolated private static func thermalStateLevel(_ thermalState: ProcessInfo.ThermalState) -> Int {
+    private static func thermalStateLevel(_ thermalState: ProcessInfo.ThermalState) -> Int {
         switch thermalState {
         case .nominal: return 0
         case .fair: return 1
@@ -646,7 +646,7 @@ enum AlertEvaluator {
         }
     }
 
-    nonisolated static func thermalStateLabel(_ thermalState: ProcessInfo.ThermalState) -> String {
+    static func thermalStateLabel(_ thermalState: ProcessInfo.ThermalState) -> String {
         switch thermalState {
         case .nominal: return "Nominal"
         case .fair: return "Fair"
@@ -656,7 +656,7 @@ enum AlertEvaluator {
         }
     }
 
-    nonisolated private static func memoryPressureLevel(_ pressure: MemoryPressureLevel) -> Int {
+    private static func memoryPressureLevel(_ pressure: MemoryPressureLevel) -> Int {
         switch pressure {
         case .green: return 0
         case .yellow: return 1
@@ -664,7 +664,7 @@ enum AlertEvaluator {
         }
     }
 
-    nonisolated static func memoryPressureLabel(_ pressure: MemoryPressureLevel) -> String {
+    static func memoryPressureLabel(_ pressure: MemoryPressureLevel) -> String {
         switch pressure {
         case .green: return "Normal"
         case .yellow: return "Elevated"

--- a/Core-Monitor/AlertModels.swift
+++ b/Core-Monitor/AlertModels.swift
@@ -7,9 +7,9 @@ enum AlertCategory: String, Codable, CaseIterable, Identifiable {
     case battery
     case services
 
-    nonisolated var id: String { rawValue }
+    var id: String { rawValue }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .thermal: return "Thermal"
         case .performance: return "Performance"
@@ -26,13 +26,13 @@ enum AlertSeverity: Int, Codable, CaseIterable, Comparable, Identifiable {
     case warning = 2
     case critical = 3
 
-    nonisolated var id: Int { rawValue }
+    var id: Int { rawValue }
 
-    nonisolated static func < (lhs: AlertSeverity, rhs: AlertSeverity) -> Bool {
+    static func < (lhs: AlertSeverity, rhs: AlertSeverity) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .none: return "Stable"
         case .info: return "Info"
@@ -56,9 +56,9 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
     case smcUnavailable
     case helperUnavailable
 
-    nonisolated var id: String { rawValue }
+    var id: String { rawValue }
 
-    nonisolated var category: AlertCategory {
+    var category: AlertCategory {
         switch self {
         case .cpuTemperature, .gpuTemperature, .overallThermalState:
             return .thermal
@@ -73,7 +73,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .cpuTemperature: return "CPU Temperature"
         case .gpuTemperature: return "GPU Temperature"
@@ -90,7 +90,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var subtitle: String {
+    var subtitle: String {
         switch self {
         case .cpuTemperature: return "Protect against sustained CPU heat."
         case .gpuTemperature: return "Protect against sustained GPU heat."
@@ -107,7 +107,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var systemImageName: String {
+    var systemImageName: String {
         switch self {
         case .cpuTemperature, .gpuTemperature, .batteryTemperature:
             return "thermometer.medium"
@@ -130,7 +130,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var unitLabel: String? {
+    var unitLabel: String? {
         switch self {
         case .cpuTemperature, .gpuTemperature, .batteryTemperature:
             return "°C"
@@ -145,7 +145,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var supportsThresholdEditing: Bool {
+    var supportsThresholdEditing: Bool {
         switch self {
         case .cpuTemperature, .gpuTemperature, .cpuUsage, .swapUsage, .batteryTemperature, .batteryHealth, .lowBatteryDischarging:
             return true
@@ -154,7 +154,7 @@ enum AlertRuleKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var supportsDesktopNotifications: Bool {
+    var supportsDesktopNotifications: Bool {
         switch self {
         case .batteryHealth:
             return false
@@ -169,7 +169,7 @@ struct AlertThreshold: Codable, Equatable {
     var critical: Double?
     var hysteresis: Double
 
-    nonisolated static let disabled = AlertThreshold(warning: nil, critical: nil, hysteresis: 0)
+    static let disabled = AlertThreshold(warning: nil, critical: nil, hysteresis: 0)
 }
 
 struct AlertRuleConfig: Codable, Equatable, Identifiable {
@@ -180,7 +180,7 @@ struct AlertRuleConfig: Codable, Equatable, Identifiable {
     var debounceSamples: Int
     var desktopNotificationsEnabled: Bool
 
-    nonisolated var id: String { kind.rawValue }
+    var id: String { kind.rawValue }
 }
 
 enum AlertPreset: String, Codable, CaseIterable, Identifiable {
@@ -189,9 +189,9 @@ enum AlertPreset: String, Codable, CaseIterable, Identifiable {
     case performance
     case aggressiveThermalSafety
 
-    nonisolated var id: String { rawValue }
+    var id: String { rawValue }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .default: return "Default"
         case .quiet: return "Quiet"
@@ -200,7 +200,7 @@ enum AlertPreset: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var subtitle: String {
+    var subtitle: String {
         switch self {
         case .default: return "Balanced thresholds with critical desktop alerts."
         case .quiet: return "Fewer desktop notifications and longer repeat windows."
@@ -215,9 +215,9 @@ enum AlertNotificationPolicy: String, Codable, CaseIterable, Identifiable {
     case criticalOnly
     case warningsAndCritical
 
-    nonisolated var id: String { rawValue }
+    var id: String { rawValue }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .inAppOnly: return "In-App Only"
         case .criticalOnly: return "Critical Only"
@@ -248,7 +248,7 @@ struct AlertRuleRuntime: Codable, Equatable {
     var dismissUntilRecovery: Bool
     var lastMetricValue: Double?
 
-    nonisolated static func initial(for kind: AlertRuleKind) -> AlertRuleRuntime {
+    static func initial(for kind: AlertRuleKind) -> AlertRuleRuntime {
         AlertRuleRuntime(
             kind: kind,
             activeSeverity: .none,
@@ -273,7 +273,7 @@ struct AlertActiveState: Equatable, Identifiable {
     let updatedAt: Date
     let metricValue: Double?
 
-    nonisolated var id: String { kind.rawValue }
+    var id: String { kind.rawValue }
 }
 
 struct AlertStore: Codable {
@@ -285,9 +285,9 @@ struct AlertStore: Codable {
     var runtimes: [AlertRuleRuntime]
     var history: [AlertEvent]
 
-    nonisolated static let historyLimit = 120
+    static let historyLimit = 120
 
-    nonisolated static func `default`() -> AlertStore {
+    static func `default`() -> AlertStore {
         let configs = AlertPreset.default.configurations()
         return AlertStore(
             selectedPreset: .default,
@@ -302,7 +302,7 @@ struct AlertStore: Codable {
 }
 
 extension AlertPreset {
-    nonisolated func configurations() -> [AlertRuleConfig] {
+    func configurations() -> [AlertRuleConfig] {
         AlertRuleKind.allCases.map { kind in
             switch (self, kind) {
             case (.default, .cpuTemperature):

--- a/Core-Monitor/Compatibility.swift
+++ b/Core-Monitor/Compatibility.swift
@@ -72,6 +72,7 @@ extension View {
 
     @ViewBuilder
     func cmLiquidGlassCard(cornerRadius: CGFloat = 14) -> some View {
+#if swift(>=6.3)
         if #available(macOS 26.0, *) {
             glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                 .overlay(
@@ -90,6 +91,18 @@ extension View {
                 }
             )
         }
+#else
+        background(
+            ZStack {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(Color.white.opacity(0.006))
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.12), lineWidth: 0.8)
+            }
+        )
+#endif
     }
 
     @ViewBuilder

--- a/Core-Monitor/FanController.swift
+++ b/Core-Monitor/FanController.swift
@@ -4,7 +4,7 @@ import AppKit
 
 // MARK: - Fan Control Modes
 
-nonisolated enum FanControlMode: String, CaseIterable {
+enum FanControlMode: String, CaseIterable {
     case smart
     case silent
     case balanced
@@ -14,11 +14,11 @@ nonisolated enum FanControlMode: String, CaseIterable {
     case custom
     case automatic
 
-    nonisolated static var quickModes: [FanControlMode] {
+    static var quickModes: [FanControlMode] {
         [.smart, .silent, .balanced, .performance, .max, .manual, .custom, .automatic]
     }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .smart:       return "SMART"
         case .silent:      return "SILENT"
@@ -31,7 +31,7 @@ nonisolated enum FanControlMode: String, CaseIterable {
         }
     }
 
-    nonisolated var shortTitle: String {
+    var shortTitle: String {
         switch self {
         case .smart:       return "SMART"
         case .silent:      return "SILENT"
@@ -44,11 +44,11 @@ nonisolated enum FanControlMode: String, CaseIterable {
         }
     }
 
-    nonisolated var usesManualSlider: Bool { self == .manual }
-    nonisolated var isManagedProfile: Bool { self != .manual && self != .automatic }
-    nonisolated var requiresPrivilegedHelper: Bool { self != .automatic }
+    var usesManualSlider: Bool { self == .manual }
+    var isManagedProfile: Bool { self != .manual && self != .automatic }
+    var requiresPrivilegedHelper: Bool { self != .automatic }
 
-    nonisolated var guidance: FanModeGuidance {
+    var guidance: FanModeGuidance {
         switch self {
         case .smart:
             return FanModeGuidance(
@@ -126,12 +126,12 @@ nonisolated enum FanControlMode: String, CaseIterable {
     }
 }
 
-nonisolated enum FanControlOwnership: Equatable {
+enum FanControlOwnership: Equatable {
     case system
     case coreMonitor
 }
 
-nonisolated struct FanModeGuidance: Equatable {
+struct FanModeGuidance: Equatable {
     let summary: String
     let detail: String
     let ownership: FanControlOwnership
@@ -142,15 +142,15 @@ nonisolated struct FanModeGuidance: Equatable {
 
 // MARK: - Custom Fan Preset Model
 
-nonisolated struct CustomFanPreset: Codable, Equatable {
-    nonisolated enum Sensor: String, Codable, CaseIterable, Identifiable {
+struct CustomFanPreset: Codable, Equatable {
+    enum Sensor: String, Codable, CaseIterable, Identifiable {
         case cpu
         case gpu
         case max
 
-        nonisolated var id: String { rawValue }
+        var id: String { rawValue }
 
-        nonisolated var title: String {
+        var title: String {
             switch self {
             case .cpu: return "CPU"
             case .gpu: return "GPU"
@@ -159,7 +159,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
         }
     }
 
-    nonisolated struct CurvePoint: Codable, Equatable, Identifiable {
+    struct CurvePoint: Codable, Equatable, Identifiable {
         let id: UUID
         var temperatureC: Double
         var speedPercent: Double
@@ -190,7 +190,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
         }
     }
 
-    nonisolated struct PowerBoost: Codable, Equatable {
+    struct PowerBoost: Codable, Equatable {
         var enabled: Bool = true
         var wattsAtMaxBoost: Double = 40
         var maxAddedTemperatureC: Double = 8
@@ -207,7 +207,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
     var powerBoost: PowerBoost?
     var points: [CurvePoint]
 
-    nonisolated static let starter = CustomFanPreset(
+    static let starter = CustomFanPreset(
         name: "Quiet ramp with thermal boost",
         version: 1,
         sensor: .max,
@@ -342,7 +342,7 @@ nonisolated struct CustomFanPreset: Codable, Equatable {
     }
 }
 
-nonisolated enum CustomPresetSaveOutcome {
+enum CustomPresetSaveOutcome {
     case success(String)
     case failure([String])
 }
@@ -351,7 +351,7 @@ nonisolated enum CustomPresetSaveOutcome {
 
 @MainActor
 final class FanController: ObservableObject {
-    nonisolated static let defaultMode: FanControlMode = .automatic
+    static let defaultMode: FanControlMode = .automatic
 
     @Published var mode: FanControlMode = FanController.defaultMode
     @Published var manualSpeed: Int = 2200

--- a/Core-Monitor/MenubarController.swift
+++ b/Core-Monitor/MenubarController.swift
@@ -43,6 +43,7 @@ enum MenuBarItemKind: CaseIterable {
 }
 
 // MARK: - MenuBarController  (public facade — same init signature as before)
+@MainActor
 final class MenuBarController: NSObject {
     private var itemControllers: [SingleMenuBarItemController] = []
     private var snapshotCancellable: AnyCancellable?
@@ -103,6 +104,7 @@ final class MenuBarController: NSObject {
 }
 
 // MARK: - SingleMenuBarItemController
+@MainActor
 final class SingleMenuBarItemController: NSObject, NSPopoverDelegate {
     private enum StatusTone: Equatable {
         case normal

--- a/Core-Monitor/MonitoringSnapshot.swift
+++ b/Core-Monitor/MonitoringSnapshot.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated enum MonitoringTrendRange: String, CaseIterable, Identifiable {
+enum MonitoringTrendRange: String, CaseIterable, Identifiable {
     case oneMinute
     case fiveMinutes
     case fifteenMinutes
@@ -24,14 +24,14 @@ nonisolated enum MonitoringTrendRange: String, CaseIterable, Identifiable {
     }
 }
 
-nonisolated enum MonitoringFreshness: Equatable {
+enum MonitoringFreshness: Equatable {
     case waiting
     case live
     case delayed
     case stale
 }
 
-nonisolated struct MonitoringSnapshotHealth: Equatable {
+struct MonitoringSnapshotHealth: Equatable {
     let freshness: MonitoringFreshness
     let sampledAt: Date?
     let age: TimeInterval?
@@ -100,12 +100,12 @@ nonisolated struct MonitoringSnapshotHealth: Equatable {
     }
 }
 
-nonisolated struct MonitoringTrendPoint: Equatable {
+struct MonitoringTrendPoint: Equatable {
     let timestamp: Date
     let value: Double
 }
 
-nonisolated struct MonitoringTrendSummary: Equatable {
+struct MonitoringTrendSummary: Equatable {
     let latest: Double
     let minimum: Double
     let maximum: Double
@@ -113,7 +113,7 @@ nonisolated struct MonitoringTrendSummary: Equatable {
     let delta: Double
 }
 
-nonisolated struct MonitoringTrendSeries {
+struct MonitoringTrendSeries {
     private(set) var points: [MonitoringTrendPoint] = []
     let retention: TimeInterval
 
@@ -164,7 +164,7 @@ nonisolated struct MonitoringTrendSeries {
     }
 }
 
-nonisolated struct ProcessActivity: Codable, Equatable, Identifiable {
+struct ProcessActivity: Codable, Equatable, Identifiable {
     let pid: Int32
     let name: String
     let cpuPercent: Double
@@ -174,7 +174,7 @@ nonisolated struct ProcessActivity: Codable, Equatable, Identifiable {
     var memoryGB: Double { Double(memoryBytes) / 1_073_741_824.0 }
 }
 
-nonisolated struct TopProcessSnapshot: Codable, Equatable {
+struct TopProcessSnapshot: Codable, Equatable {
     var sampledAt: Date
     var topCPU: [ProcessActivity]
     var topMemory: [ProcessActivity]
@@ -182,7 +182,7 @@ nonisolated struct TopProcessSnapshot: Codable, Equatable {
     static let empty = TopProcessSnapshot(sampledAt: .distantPast, topCPU: [], topMemory: [])
 }
 
-nonisolated struct SystemMonitorSnapshot {
+struct SystemMonitorSnapshot {
     var sampledAt: Date = .distantPast
     var cpuTemperature: Double?
     var gpuTemperature: Double?

--- a/Core-Monitor/MonitoringSnapshot.swift
+++ b/Core-Monitor/MonitoringSnapshot.swift
@@ -5,9 +5,9 @@ nonisolated enum MonitoringTrendRange: String, CaseIterable, Identifiable {
     case fiveMinutes
     case fifteenMinutes
 
-    nonisolated var id: String { rawValue }
+    var id: String { rawValue }
 
-    nonisolated var title: String {
+    var title: String {
         switch self {
         case .oneMinute: return "1m"
         case .fiveMinutes: return "5m"
@@ -15,7 +15,7 @@ nonisolated enum MonitoringTrendRange: String, CaseIterable, Identifiable {
         }
     }
 
-    nonisolated var duration: TimeInterval {
+    var duration: TimeInterval {
         switch self {
         case .oneMinute: return 60
         case .fiveMinutes: return 5 * 60
@@ -170,8 +170,8 @@ nonisolated struct ProcessActivity: Codable, Equatable, Identifiable {
     let cpuPercent: Double
     let memoryBytes: UInt64
 
-    nonisolated var id: String { "\(pid)-\(name)" }
-    nonisolated var memoryGB: Double { Double(memoryBytes) / 1_073_741_824.0 }
+    var id: String { "\(pid)-\(name)" }
+    var memoryGB: Double { Double(memoryBytes) / 1_073_741_824.0 }
 }
 
 nonisolated struct TopProcessSnapshot: Codable, Equatable {
@@ -179,7 +179,7 @@ nonisolated struct TopProcessSnapshot: Codable, Equatable {
     var topCPU: [ProcessActivity]
     var topMemory: [ProcessActivity]
 
-    nonisolated static let empty = TopProcessSnapshot(sampledAt: .distantPast, topCPU: [], topMemory: [])
+    static let empty = TopProcessSnapshot(sampledAt: .distantPast, topCPU: [], topMemory: [])
 }
 
 nonisolated struct SystemMonitorSnapshot {
@@ -219,5 +219,5 @@ nonisolated struct SystemMonitorSnapshot {
     var hasSMCAccess: Bool = false
     var lastError: String?
 
-    nonisolated static let empty = SystemMonitorSnapshot()
+    static let empty = SystemMonitorSnapshot()
 }

--- a/Core-Monitor/SMCHelperXPC.swift
+++ b/Core-Monitor/SMCHelperXPC.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc protocol SMCHelperXPCProtocol {
-    nonisolated func setFanManual(_ fanID: Int, rpm: Int, withReply reply: @escaping (NSString?) -> Void)
-    nonisolated func setFanAuto(_ fanID: Int, withReply reply: @escaping (NSString?) -> Void)
-    nonisolated func readValue(_ key: String, withReply reply: @escaping (NSNumber?, NSString?) -> Void)
+    func setFanManual(_ fanID: Int, rpm: Int, withReply reply: @escaping (NSString?) -> Void)
+    func setFanAuto(_ fanID: Int, withReply reply: @escaping (NSString?) -> Void)
+    func readValue(_ key: String, withReply reply: @escaping (NSNumber?, NSString?) -> Void)
 }

--- a/Core-Monitor/SMCHelperXPC.swift
+++ b/Core-Monitor/SMCHelperXPC.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc protocol SMCHelperXPCProtocol {
-    func setFanManual(_ fanID: Int, rpm: Int, withReply reply: @escaping (NSString?) -> Void)
-    func setFanAuto(_ fanID: Int, withReply reply: @escaping (NSString?) -> Void)
-    func readValue(_ key: String, withReply reply: @escaping (NSNumber?, NSString?) -> Void)
+    nonisolated func setFanManual(_ fanID: Int, rpm: Int, withReply reply: @escaping (NSString?) -> Void)
+    nonisolated func setFanAuto(_ fanID: Int, withReply reply: @escaping (NSString?) -> Void)
+    nonisolated func readValue(_ key: String, withReply reply: @escaping (NSNumber?, NSString?) -> Void)
 }

--- a/Core-Monitor/SystemMonitor.swift
+++ b/Core-Monitor/SystemMonitor.swift
@@ -5,19 +5,19 @@ import IOKit.ps
 import Darwin
 import CoreAudio
 
-nonisolated struct CPUStats {
+struct CPUStats {
     let usagePercent: Double
     let performanceCoreUsagePercent: Double?
     let efficiencyCoreUsagePercent: Double?
 }
 
-nonisolated enum MemoryPressureLevel {
+enum MemoryPressureLevel {
     case green
     case yellow
     case red
 }
 
-nonisolated struct MemoryStats {
+struct MemoryStats {
     let usagePercent: Double
     let usedGB: Double
     let totalGB: Double
@@ -32,7 +32,7 @@ nonisolated struct MemoryStats {
     let swapTotalBytes: UInt64
 }
 
-nonisolated struct BatteryInfo {
+struct BatteryInfo {
     var hasBattery: Bool = false
     var chargePercent: Int?
     var isCharging: Bool = false
@@ -51,7 +51,7 @@ nonisolated struct BatteryInfo {
 }
 
 // MARK: - Disk stats
-nonisolated struct DiskStats {
+struct DiskStats {
     var totalGB: Double = 0
     var usedGB: Double = 0
     var freeGB: Double = 0
@@ -154,7 +154,7 @@ final class SystemMonitor: ObservableObject {
     var ssdTemperature: Double? { snapshot.ssdTemperature }
 
     // MARK: - Network throughput (bytes/sec since last sample)
-    nonisolated struct NetworkStats {
+    struct NetworkStats {
         var uploadBytesPerSec:   Double = 0
         var downloadBytesPerSec: Double = 0
     }

--- a/Core-Monitor/TopProcessSampler.swift
+++ b/Core-Monitor/TopProcessSampler.swift
@@ -2,7 +2,6 @@ import AppKit
 import Darwin
 import Foundation
 
-@MainActor
 final class TopProcessSampler {
     private struct SampledProcess {
         let pid: pid_t
@@ -104,7 +103,7 @@ final class TopProcessSampler {
         }
     }
 
-    nonisolated private func collectProcesses(
+    private func collectProcesses(
         elapsed: TimeInterval,
         processorCount: Int,
         previousCPUTimeByPID: [pid_t: UInt64]
@@ -144,7 +143,7 @@ final class TopProcessSampler {
             }
     }
 
-    nonisolated private func aggregateProcesses(_ processes: [SampledProcess]) -> [AggregatedProcess] {
+    private func aggregateProcesses(_ processes: [SampledProcess]) -> [AggregatedProcess] {
         var grouped: [String: AggregatedProcess] = [:]
 
         for process in processes {
@@ -164,7 +163,7 @@ final class TopProcessSampler {
             .filter { $0.cpuPercent >= 0.5 || $0.memoryBytes > 0 }
     }
 
-    nonisolated private func taskInfo(for pid: pid_t) -> proc_taskinfo? {
+    private func taskInfo(for pid: pid_t) -> proc_taskinfo? {
         var info = proc_taskinfo()
         let result = withUnsafeMutablePointer(to: &info) { pointer -> Int32 in
             pointer.withMemoryRebound(to: Int8.self, capacity: MemoryLayout<proc_taskinfo>.stride) { rebounded in
@@ -176,7 +175,7 @@ final class TopProcessSampler {
         return info
     }
 
-    nonisolated private func cpuTime(for pid: pid_t) -> UInt64? {
+    private func cpuTime(for pid: pid_t) -> UInt64? {
         var usage = rusage_info_current()
         let status = withUnsafeMutablePointer(to: &usage) { pointer -> Int32 in
             pointer.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rebounded in
@@ -188,7 +187,7 @@ final class TopProcessSampler {
         return usage.ri_user_time + usage.ri_system_time
     }
 
-    nonisolated private func displayName(for pid: pid_t) -> String {
+    private func displayName(for pid: pid_t) -> String {
         if let runningApp = NSRunningApplication(processIdentifier: pid) {
             let localizedName = runningApp.localizedName ?? ""
             if !localizedName.isEmpty {

--- a/Core-Monitor/TouchBarUtilityWidgets.swift
+++ b/Core-Monitor/TouchBarUtilityWidgets.swift
@@ -228,6 +228,7 @@ enum SystemBrightness {
 }
 
 @available(macOS 13.0, *)
+@MainActor
 final class ControlCenterSliderPresenter: NSObject, NSTouchBarDelegate {
     enum SliderKind {
         case brightness

--- a/Core-Monitor/WeatherService.swift
+++ b/Core-Monitor/WeatherService.swift
@@ -35,6 +35,7 @@ protocol WeatherProviding: AnyObject {
     func currentWeather(for location: CLLocation) async throws -> WeatherSnapshot
 }
 
+@MainActor
 protocol WeatherLocationAccessControlling: AnyObject {
     var authorizationStatus: CLAuthorizationStatus { get }
     var currentLocation: CLLocation? { get }
@@ -71,8 +72,11 @@ final class WeatherLocationAccessController: NSObject, ObservableObject, CLLocat
         authorizationStatus = locationManager.authorizationStatus
     }
 
-    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        authorizationStatus = manager.authorizationStatus
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor [weak self] in
+            self?.authorizationStatus = status
+        }
     }
 }
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -208,6 +208,6 @@
 - Rebuilt the macOS app, reran the full `xcodebuild ... test` suite, and runtime-smoke-tested the Debug build by relaunching it and confirming the live menu bar items still update (`CPU`, `MEM`, `SSD`, and temperature).
 
 ### Completed batch
-- Marked the monitoring snapshot value layer as explicitly `nonisolated` so pure telemetry models no longer inherit the app target's default `MainActor` isolation by accident.
-- Extended the same cleanup to `BatteryInfo`, `DiskStats`, `MemoryStats`, `NetworkStats`, and the related monitoring enums, which removes a cluster of Swift 6 concurrency warnings from the build.
-- Re-ran the full `xcodebuild -project Core-Monitor.xcodeproj -scheme Core-Monitor -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test` suite and confirmed the earlier actor-isolation warnings no longer appear in the compile output.
+- Reverted invalid `nonisolated` annotations from the fan and monitoring value-model layer so the project still compiles on GitHub Actions' Xcode 16.2 runner.
+- Kept the truly actor-crossing cases explicit by leaving helper probe methods nonisolated, moving the Touch Bar slider presenter onto the main actor, and making the process sampler itself plain so `SystemMonitor` can construct it synchronously.
+- Re-ran `xcodebuild -project Core-Monitor.xcodeproj -scheme Core-Monitor -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test` and confirmed the repo is back to a green local build before pushing the CI repair.


### PR DESCRIPTION
## Summary
- remove invalid `nonisolated` annotations from monitoring and system model value types so GitHub Actions' Xcode 16.2 runner can compile `main` again
- keep the actual actor-crossing cases explicit by leaving XPC helper probes nonisolated, making the Touch Bar slider presenter main-actor isolated, and keeping the process sampler constructible from `SystemMonitor`
- align weather/location access protocol isolation and correct the worklog entry to reflect the real CI repair

## Verification
- `xcodebuild -project Core-Monitor.xcodeproj -scheme Core-Monitor -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test`

## Root cause
The current failing `CI / Build and Test (push)` run on `main` is rejecting `nonisolated` on plain structs/enums in `MonitoringSnapshot.swift` and `SystemMonitor.swift` under GitHub Actions' Xcode 16.2 toolchain.