### PR TITLE
Add export compliance plist flag

### DIFF
--- a/App-Info.plist
+++ b/App-Info.plist
@@ -24,6 +24,8 @@
 	<string>public.app-category.utilities</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Core-Monitor uses your location for the optional Touch Bar weather item.</string>
 	<key>SMPrivilegedExecutables</key>


### PR DESCRIPTION
## Summary
- add `ITSAppUsesNonExemptEncryption = NO` to the shipping app Info.plist
- keep the change scoped to the active app target plist only
- avoid including unrelated local changes

## Why
Apple's export-compliance guidance says apps can declare `ITSAppUsesNonExemptEncryption` in Info.plist to skip repeated encryption questions when the app uses only exempt OS-provided encryption or no non-exempt encryption. Repo evidence here shows WeatherKit/system networking and Security framework use for entitlement/signing inspection, with no custom crypto implementation.