### PR TITLE
Add Mac App Store download links and clarify README App Store messaging

### DIFF
--- a/Mac-App-Store/index.html
+++ b/Mac-App-Store/index.html
@@ -50,7 +50,8 @@
           <h1>Core-Monitor</h1>
           <p class="hero-lead">Sandboxed, read-only system monitoring for modern Macs, optimized for Apple silicon.</p>
           <div class="hero-actions">
-            <a class="button primary" href="#scope">See App Store Scope</a>
+            <a class="button primary" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download on the App Store</a>
+            <a class="button secondary" href="#scope">See App Store Scope</a>
             <a class="button secondary" href="support/">Support</a>
             <a class="button secondary" href="privacy/">Privacy Policy</a>
           </div>
@@ -137,7 +138,7 @@
         <div class="closing-actions">
           <a class="button secondary" href="support/">Support</a>
           <a class="button secondary" href="privacy/">Privacy Policy</a>
-          <a class="button primary" href="#scope">Review App Store Scope</a>
+          <a class="button primary" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download on the App Store</a>
         </div>
       </section>
     </main>

--- a/Mac-App-Store/privacy/index.html
+++ b/Mac-App-Store/privacy/index.html
@@ -39,6 +39,7 @@
       </a>
       <div class="header-actions">
         <a class="back-link" href="../support/">Support</a>
+        <a class="back-link" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download</a>
         <a class="back-link" href="../">App Store page</a>
       </div>
     </header>
@@ -51,7 +52,8 @@
           <p class="hero-lead">Core-Monitor for the Mac App Store does not require an account, run analytics SDKs, or build remote profiles.</p>
           <p class="policy-meta">Effective April 20, 2026. This policy applies to the Mac App Store edition of Core-Monitor.</p>
           <div class="hero-actions">
-            <a class="button primary" href="../">Back to App Store page</a>
+            <a class="button primary" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download on the App Store</a>
+            <a class="button secondary" href="../">App Store page</a>
             <a class="button secondary" href="../support/">Support</a>
           </div>
         </div>

--- a/Mac-App-Store/support/index.html
+++ b/Mac-App-Store/support/index.html
@@ -39,6 +39,7 @@
       </a>
       <div class="header-actions">
         <a class="back-link" href="../privacy/">Privacy Policy</a>
+        <a class="back-link" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download</a>
         <a class="back-link" href="../">App Store page</a>
       </div>
     </header>
@@ -53,6 +54,7 @@
           <div class="hero-actions">
             <a class="button primary" href="mailto:coremonitor.app@gmail.com">Email Support</a>
             <a class="button secondary" href="../privacy/">Privacy Policy</a>
+            <a class="button secondary" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12" target="_blank" rel="noopener">Download on App Store</a>
             <a class="button secondary" href="../">App Store page</a>
           </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It is written in Swift and built around `host_statistics`, `IOKit`, and `IOPSCop
 
 Public builds are available through GitHub Releases as a signed DMG for standard installs and a signed ZIP for archive-friendly installs.
 
-There is also a separate Core-Monitor Mac App Store edition. That variant is sandboxed and intentionally different: it keeps read-only monitoring features that fit App Store rules, and excludes the helper, fan control, AppleSMC access, private-framework paths, and other elevated or non-App-Store behavior.
+There is also a separate Core-Monitor Mac App Store edition: https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12. That variant is sandboxed and intentionally different: it keeps read-only monitoring features that fit App Store rules, and excludes the helper, fan control, AppleSMC access, private-framework paths, and other elevated or non-App-Store behavior.
 
 ## Why people choose Core-Monitor
 
@@ -67,6 +67,7 @@ Choose Core-Monitor when you want:
 
 Direct download:
 
+- Download from the [Mac App Store](https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12) if you want the sandboxed App Store edition.
 - Download [Core-Monitor.dmg](https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg) for the normal drag-to-Applications install.
 - Open the disk image, drag `Core-Monitor.app` into `/Applications`, then eject the disk image.
 - Download [Core-Monitor.app.zip](https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.app.zip) if you prefer the raw app archive.
@@ -322,7 +323,7 @@ Open the project in Xcode, select the `Core-Monitor` scheme, and build. The `smc
 - macOS 12 or later
 - Apple Silicon is the primary target; Intel Macs are not part of the current test path
 - Fan control requires macOS 13+ (XPC with code-signing requirements)
-- Core-Monitor is not available on the Mac App Store
+- A separate sandboxed App Store build is available: https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12
 
 ## Privacy
 


### PR DESCRIPTION
### Motivation
- Resolve contradictory README messaging that said the app was not on the Mac App Store while an App Store edition exists. 
- Surface a direct App Store download link in the App Store landing, support, and privacy pages so users can reach the approved listing quickly. 
- Improve discoverability and reduce brand/installation confusion between the sandboxed App Store build and the direct-download build. 

### Description
- Added the App Store URL `https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12` to the README install section and compatibility notes and removed the contradictory “not available on the Mac App Store” line. 
- Updated the Mac App Store landing page (`Mac-App-Store/index.html`) to include a prominent “Download on the App Store” CTA in the hero and closing actions. 
- Added direct App Store download links to `Mac-App-Store/support/index.html` and `Mac-App-Store/privacy/index.html` headers and main action areas so support and privacy pages point users at the store listing. 
- Files changed: `README.md`, `Mac-App-Store/index.html`, `Mac-App-Store/support/index.html`, `Mac-App-Store/privacy/index.html`. 

### Testing
- Ran `rg -n "apps.apple.com/us/app/core-monitor/id6762558526\?mt=12|not available on the Mac App Store" README.md Mac-App-Store/index.html Mac-App-Store/support/index.html Mac-App-Store/privacy/index.html` and confirmed the App Store URL appears in the intended locations and the contradictory sentence was removed. 
- Inspected the updated files with `nl -ba` to validate CTA placement in the hero and closing sections of `Mac-App-Store/index.html` and link placements in support/privacy pages. 
- Verified working tree changes are present with `git status --short` and created PR metadata via the project PR tooling for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b27533d48324be2dabbff98b2e13)