### PR TITLE
security: add OpenSSF checks and provenance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @offyotto

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Change
+
+Describe the problem and the change.
+
+## Verification
+
+List the checks you ran.
+
+- [ ] Tests cover the changed behavior.
+- [ ] User-facing changes are documented.
+- [ ] Security-sensitive changes were reviewed for privilege, XPC, signing, and SMC impact.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - release/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   macos-tests:
     name: Build and Test
@@ -17,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 jobs:
   notarized-release:
@@ -27,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
@@ -177,7 +180,7 @@ jobs:
           } >> "${GITHUB_ENV}"
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: core-monitor-release
           path: |
@@ -187,6 +190,13 @@ jobs:
             build/release/Core-Monitor.dmg.sha256
             build/release/core-monitor.rb
             build/release/Core-Monitor.xcarchive
+
+      - name: Attest release artifacts
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: |
+            build/release/Core-Monitor.app.zip
+            build/release/Core-Monitor.dmg
 
       - name: Create or update GitHub Release
         if: github.event_name == 'push' || github.event.inputs.create_release == 'true'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload Scorecard results
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   <img src="https://img.shields.io/badge/apple%20silicon-native-black?style=flat&logo=apple" alt="apple silicon native">
   <img src="https://img.shields.io/badge/price-free-2ea44f?style=flat" alt="free">
   <img src="https://img.shields.io/badge/license-gpl--3.0-blue?style=flat" alt="gpl-3.0 license">
+  <a href="https://github.com/offyotto/Core-Monitor/actions/workflows/ci.yml"><img src="https://github.com/offyotto/Core-Monitor/actions/workflows/ci.yml/badge.svg" alt="build and test"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/offyotto/Core-Monitor"><img src="https://api.securityscorecards.dev/projects/github.com/offyotto/Core-Monitor/badge" alt="openssf scorecard"></a>
 </p>
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please do not open a public GitHub issue for security vulnerabilities.
 
-If you find a vulnerability in Core-Monitor, report it privately through the repository owner profile or by opening a private security advisory if that option is available.
+If you find a vulnerability in Core-Monitor, [open a private security advisory](https://github.com/offyotto/Core-Monitor/security/advisories/new).
 
 Include:
 


### PR DESCRIPTION
Adds weekly OpenSSF Scorecard reporting, GitHub Actions updates, CODEOWNERS, a pull request checklist, read-only CI permissions, and signed release provenance.

Checks: `actionlint .github/workflows/*.yml` and the full Xcode test suite passed.