### PR TITLE
Scope release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,18 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
-  artifact-metadata: write
+permissions: read-all
 
 jobs:
   notarized-release:
     name: Build, Notarize, and Publish
     runs-on: macos-14
     timeout-minutes: 60
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
The release job needs write access to publish and attest artifacts. Granting that access at workflow scope gives every job the same token permissions.

Set the workflow default to read-only and grant write permissions only to the release job.

Check: actionlint 1.7.12