### PR TITLE
Remove unused CI branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - codex/**
       - feature/**
       - release/**
   pull_request:


### PR DESCRIPTION
Pull requests already run the full CI workflow. Remove the unused extra push trigger so CI only runs for main, feature, and release branches plus every pull request.

Check: actionlint 1.7.12