### PR TITLE
Refresh OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <img src="https://img.shields.io/badge/price-free-2ea44f?style=flat" alt="free">
   <img src="https://img.shields.io/badge/license-gpl--3.0-blue?style=flat" alt="gpl-3.0 license">
   <a href="https://github.com/offyotto/Core-Monitor/actions/workflows/ci.yml"><img src="https://github.com/offyotto/Core-Monitor/actions/workflows/ci.yml/badge.svg" alt="build and test"></a>
-  <a href="https://securityscorecards.dev/viewer/?uri=github.com/offyotto/Core-Monitor"><img src="https://api.securityscorecards.dev/projects/github.com/offyotto/Core-Monitor/badge" alt="openssf scorecard"></a>
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/offyotto/Core-Monitor"><img src="https://api.securityscorecards.dev/projects/github.com/offyotto/Core-Monitor/badge?run=29832249303-2" alt="openssf scorecard"></a>
 </p>
 
 ---


### PR DESCRIPTION
Refreshes the README badge after the latest OpenSSF Scorecard run published a 7.7 score.

Signed-Releases is now 8/10, with all five recent releases containing signed artifacts.

Checked with the completed Scorecard workflow run and the published OpenSSF API result.