### PR TITLE
Add Pock attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -672,3 +672,45 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+-------------------------------------------------------------------------------
+Third-party notices
+-------------------------------------------------------------------------------
+
+Parts of Core-Monitor's Touch Bar implementation are adapted from:
+
+Pock
+https://github.com/pock/pock
+Copyright (c) 2017 Pierluigi Galdi
+
+PockKit
+https://github.com/pock/pockkit
+Copyright (c) 2019 Pock <support@pock.app>
+
+Pock Status Widget
+https://github.com/pock/status-widget
+Copyright (c) 2019-2020 Pierluigi Galdi. All rights reserved.
+
+Pock Weather Widget
+https://github.com/pock/weather-widget
+Copyright (c) 2019 Pierluigi Galdi. All rights reserved.
+
+Pock and PockKit are licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Change

Add Pock, PockKit, Status Widget, and Weather Widget attribution to `LICENSE`.

## Verification

Checked the notices against the upstream repositories. No application code changed.

- [ ] Tests cover the changed behavior.
- [x] User-facing changes are documented.
- [ ] Security-sensitive changes were reviewed for privilege, XPC, signing, and SMC impact.