### PR TITLE
Cancel superseded CI runs and keep test result bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - main
-      - feature/**
-      - release/**
   pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macos-tests:
@@ -26,10 +28,26 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Record toolchain versions
+        run: |
+          sw_vers
+          xcodebuild -version
+
       - name: Run macOS test suite
         run: |
           xcodebuild test \
             -project Core-Monitor.xcodeproj \
             -scheme Core-Monitor \
             -destination 'platform=macOS' \
+            -enableCodeCoverage YES \
+            -resultBundlePath build/ci/Core-Monitor.xcresult \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload test result bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: core-monitor-ci-results
+          path: build/ci/Core-Monitor.xcresult
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Change

CI had no `concurrency` group, so a push to `main` and its pull request each started a full 30 minute macOS job and both ran to completion even when a newer commit had already superseded them. The `feature/**` and `release/**` push triggers also duplicated the `pull_request` trigger for in-repo branches. On failure the run produced no retrievable diagnostics, only scrollback in the log.

This adds a `concurrency` group keyed on the ref with `cancel-in-progress`, narrows the push trigger to `main` so pull requests are covered once, records `sw_vers` and `xcodebuild -version` so the resolved toolchain is visible in the log, and writes an `.xcresult` bundle that is uploaded as an artifact on both success and failure. The test invocation itself is unchanged apart from `-enableCodeCoverage YES` and `-resultBundlePath`, and the scheme, destination, and `CODE_SIGNING_ALLOWED=NO` behavior are preserved.

## Verification

- [ ] Tests cover the changed behavior.
- [x] User-facing changes are documented.
- [x] Security-sensitive changes were reviewed for privilege, XPC, signing, and SMC impact.

This change is CI configuration only and touches no application, helper, XPC, signing, or SMC code. `permissions` remains `contents: read`, and both actions stay pinned to the commit SHAs already trusted elsewhere in this repository.

I could not run Xcode locally, so the workflow run on this pull request is the verification. It should show one `Build and Test` job rather than a duplicate pair, a `Record toolchain versions` step naming the resolved Xcode, and a `core-monitor-ci-results` artifact.

I did not pin `xcode-version` to an exact release. Pinning to a version the `macos-14` image does not carry would break CI outright, and the current value is what your passing runs already resolve. Once this run prints the version, pinning becomes a safe one line follow up.