### PR TITLE
Check release tags use vMAJOR.MINOR.PATCH

### DIFF
--- a/.github/workflows/tag-format.yml
+++ b/.github/workflows/tag-format.yml
@@ -1,0 +1,29 @@
+name: Tag Format
+
+on:
+  push:
+    tags:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  check-tag-format:
+    name: Check Release Tag Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Require vMAJOR.MINOR.PATCH
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if printf '%s' "${TAG_NAME}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "Tag ${TAG_NAME} matches vMAJOR.MINOR.PATCH."
+            exit 0
+          fi
+
+          echo "Tag ${TAG_NAME} is not a valid release tag." >&2
+          echo "Expected vMAJOR.MINOR.PATCH, for example v16.0.0, with an optional prerelease suffix such as v16.0.0-rc.1." >&2
+          exit 1


### PR DESCRIPTION
## Change

Published tags are not machine comparable. The history contains `v16`, `v15`, `v14.0.9`, `v14.08`, `v14.06`, `v14.0.5`, `v14.0.4`, `14.0.2`, and `v14.0.2rc1`, which mixes the `v` prefix, mixes two and three segment versions, and mixes prerelease styles. Under version comparison `v14.08` sorts below `v14.0.9` while actually being the later release, and `release.yml` triggers on `v*`, so any of these shapes starts a full signed release. The generated Homebrew cask version and any future update feed both depend on comparable versions.

This adds a five minute workflow that runs on tag pushes and fails when the tag is not `vMAJOR.MINOR.PATCH`, with an optional prerelease suffix such as `v16.0.0-rc.1`. It only reads the tag name and changes no release behavior, so existing tags stay untouched and a correctly named tag releases exactly as before.

## Verification

- [x] Tests cover the changed behavior.
- [x] User-facing changes are documented.
- [x] Security-sensitive changes were reviewed for privilege, XPC, signing, and SMC impact.

The check reads `github.ref_name`, runs no repository code, and declares `permissions: contents: read`. It touches no application, helper, XPC, signing, or SMC code.

I ran the exact match expression from the workflow against every tag this repository has published. It accepts `v16.0.0` and `v16.0.0-rc.1` and rejects `v16`, `v15`, `v14.08`, `v14.06`, `14.0.2`, and `v14.0.2rc1`.

One placement note. Fail fast would be better inside `release.yml` ahead of the 60 minute build, but that would mean rewriting a file containing a templated download URL I could not reproduce with confidence, so I kept this standalone rather than risk that file. Moving the step into `release.yml` later is a safe follow up.