### PR TITLE
Site: performance, accessibility, and a de-AI pass on the homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,35 +3,48 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="dark light">
+  <!-- Everything this page needs is served from this origin, so the policy can
+       stay strict. If you ever add a webfont, analytics or an embed, widen the
+       matching directive below or the browser will silently block it. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:; media-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; form-action 'none'; upgrade-insecure-requests">
   <title>Core-Monitor | Apple Silicon System Monitor and Fan Control for macOS</title>
   <meta name="description" content="Core-Monitor is a free, open-source system monitor for Apple Silicon Macs. It reads CPU load, temperature, power draw, memory, battery and fan speed, and can hand you the fans when you want them. Nothing leaves the Mac.">
   <meta name="application-name" content="Core-Monitor">
   <meta name="apple-mobile-web-app-title" content="Core-Monitor">
+  <meta name="author" content="offyotto">
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
   <meta name="theme-color" content="#07080b" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#f1f2ef" media="(prefers-color-scheme: light)">
   <link rel="canonical" href="https://offyotto.github.io/Core-Monitor/">
-  <link rel="alternate" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">
+  <link rel="manifest" href="manifest.webmanifest">
   <link rel="icon" href="favicon.ico?v=6" sizes="any">
   <link rel="icon" type="image/png" sizes="512x512" href="images/site/core-monitor-logo.png?v=6">
-  <link rel="shortcut icon" href="images/site/core-monitor-logo.png?v=6">
   <link rel="apple-touch-icon" href="images/site/core-monitor-logo.png?v=6">
   <meta property="og:site_name" content="Core-Monitor">
   <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_US">
   <meta property="og:title" content="Core-Monitor | Apple Silicon System Monitor and Fan Control for macOS">
   <meta property="og:description" content="A free, open-source monitor for Apple Silicon Macs. Temperature, power, memory, battery and fans in one native window. Nothing leaves the machine.">
   <meta property="og:url" content="https://offyotto.github.io/Core-Monitor/">
   <meta property="og:image" content="https://offyotto.github.io/Core-Monitor/images/ui/overview-v16.png?v=16">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1192">
+  <meta property="og:image:height" content="884">
   <meta property="og:image:alt" content="Core-Monitor dashboard showing CPU, memory, thermal, cooling, power, network and storage readings.">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Core-Monitor | Apple Silicon System Monitor and Fan Control for macOS">
   <meta name="twitter:description" content="A free, open-source monitor for Apple Silicon Macs. Temperature, power, memory, battery and fans in one native window.">
   <meta name="twitter:image" content="https://offyotto.github.io/Core-Monitor/images/ui/overview-v16.png?v=16">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;600&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css?v=9">
-  <link rel="stylesheet" href="https://unpkg.com/lenis@1.3.23/dist/lenis.css">
+  <meta name="twitter:image:alt" content="Core-Monitor dashboard showing CPU, memory, thermal, cooling, power, network and storage readings.">
+  <!-- The hero screenshot is the largest element on first paint, so it is
+       fetched at the same priority as the stylesheet rather than waiting for
+       the parser to reach the <img>. -->
+  <link rel="preload" as="image" href="images/ui/overview-v16.png?v=16" fetchpriority="high">
+  <link rel="stylesheet" href="styles.css?v=16">
+  <!-- Type is set in the system UI font (SF Pro on macOS), so there are no
+       webfont requests and nothing about a visitor reaches a third party. -->
+  <script src="script.js?v=7" defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -41,6 +54,7 @@
         "@id": "https://offyotto.github.io/Core-Monitor/#website",
         "name": "Core-Monitor",
         "url": "https://offyotto.github.io/Core-Monitor/",
+        "inLanguage": "en",
         "description": "Core-Monitor is a free, open-source system monitor for Apple Silicon Macs with temperature, power, memory, battery, menu bar readouts, local alerts, Touch Bar widgets, and optional fan control."
       },
       {
@@ -49,11 +63,13 @@
         "name": "Core-Monitor",
         "operatingSystem": "macOS 13 or later",
         "applicationCategory": "UtilitiesApplication",
+        "applicationSubCategory": "System monitor",
         "softwareRequirements": "Apple Silicon Mac, macOS 13 or later",
         "description": "Core-Monitor is a native macOS system monitor for Apple Silicon. It reads temperature, CPU, GPU, memory, battery, power draw and fan speed locally, with alerts, menu bar readouts and optional fan control.",
         "url": "https://offyotto.github.io/Core-Monitor/",
         "downloadUrl": "https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg",
         "installUrl": "https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg",
+        "releaseNotes": "https://github.com/offyotto/Core-Monitor/releases/latest",
         "isAccessibleForFree": true,
         "featureList": [
           "Temperature, power, battery, CPU, GPU, memory and fan readings on Apple Silicon",
@@ -73,6 +89,10 @@
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "license": "https://github.com/offyotto/Core-Monitor/blob/main/LICENSE",
         "codeRepository": "https://github.com/offyotto/Core-Monitor",
+        "softwareHelp": {
+          "@type": "CreativeWork",
+          "url": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/support/"
+        },
         "sameAs": [
           "https://github.com/offyotto/Core-Monitor",
           "https://github.com/offyotto/Core-Monitor/releases",
@@ -86,7 +106,7 @@
         "mainEntity": [
           {
             "@type": "Question",
-            "name": "Which Macs can run Core-Monitor?",
+            "name": "Which Macs can run it?",
             "acceptedAnswer": {
               "@type": "Answer",
               "text": "Apple Silicon Macs on macOS 13 or later. The sensors and fan interfaces it reads are specific to Apple's own chips, so Intel Macs are not supported."
@@ -94,26 +114,42 @@
           },
           {
             "@type": "Question",
-            "name": "Do I need to install the privileged helper?",
+            "name": "Do I need the helper installed?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "No. Every reading works without it. The helper exists only so the app can write fan speeds, and control can be handed back to macOS at any time."
+              "text": "No. Every reading works without it. It exists only so the app can write fan speeds, and you can hand control back to macOS whenever you like."
             }
           },
           {
             "@type": "Question",
-            "name": "Does Core-Monitor send data anywhere?",
+            "name": "Does it phone home?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "No. There is no analytics code, no crash reporter, and no account. The only network feature is optional WeatherKit weather for the Touch Bar."
+              "text": "No. There is no analytics code and no account anywhere in the app. The one network call is optional WeatherKit weather for the Touch Bar, and it only runs if you switch it on."
             }
           },
           {
             "@type": "Question",
-            "name": "How does it compare to iStat Menus, TG Pro or Stats?",
+            "name": "Can fan control damage my Mac?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Core-Monitor stays narrow on purpose, focused on heat, power and fans rather than every metric on the system. It is free, open source, and keeps everything local."
+              "text": "macOS keeps its own thermal limits regardless of what any app requests. Core-Monitor also keeps an obvious way out: one click gives full control back to the system."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is deliberately left out?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Cloud dashboards, fleet management, and a metric for every corner of the OS. The scope stays heat, power, memory, battery and fans, done properly."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where do bug reports go?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Open an issue on the GitHub tracker at https://github.com/offyotto/Core-Monitor/issues. Release notes and older builds live on the releases page at https://github.com/offyotto/Core-Monitor/releases."
             }
           }
         ]
@@ -128,10 +164,10 @@
   <header class="site-header">
     <div class="wrap header-row">
       <a class="brand" href="#top">
-        <img class="brand-mark" src="images/site/core-monitor-logo.png?v=6" alt="Core-Monitor app icon">
+        <img class="brand-mark" src="images/site/core-monitor-logo.png?v=6" alt="" width="30" height="30">
         <span class="brand-text">Core-Monitor</span>
       </a>
-      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="primary-nav" aria-label="Toggle navigation">
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="primary-nav" aria-label="Open menu">
         <span></span>
       </button>
       <nav class="primary-nav" id="primary-nav" data-nav aria-label="Sections">
@@ -157,16 +193,19 @@
   <main id="main">
     <section class="wrap hero" id="top">
       <div class="hero-copy">
-        <h1>Your Mac already knows how hot it's running. <span class="mark">Now you can watch too.</span></h1>
+        <p class="eyebrow">Free &middot; Open source &middot; Apple silicon</p>
+        <h1>Your Mac already knows how hot it&rsquo;s running. <span class="mark">Now you can watch too.</span></h1>
+        <p class="hero-text">Core-Monitor reads temperature, CPU and GPU load, power draw, memory, battery and fan speed straight from your Mac&rsquo;s own sensors, then puts them in one native window and the menu bar. No account, no telemetry, and optional fan control for when you want it.</p>
         <div class="hero-actions btn-group">
           <a class="btn btn-solid" href="https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg">Download for macOS</a>
           <a class="btn btn-outline" href="Mac-App-Store/">Mac App Store edition</a>
           <a class="btn btn-ghost" href="https://github.com/offyotto/Core-Monitor">Read the source</a>
         </div>
+        <p class="meta-line">macOS 13 or later &middot; Apple silicon &middot; About 5 MB</p>
       </div>
       <div class="hero-visual">
         <figure class="frame">
-          <img src="images/ui/overview-v16.png?v=16" alt="Core-Monitor dashboard with CPU, memory, thermal, cooling, power, network and storage readings." width="1192" height="884">
+          <img src="images/ui/overview-v16.png?v=16" alt="Core-Monitor dashboard with CPU, memory, thermal, cooling, power, network and storage readings." width="1192" height="884" fetchpriority="high" decoding="async">
         </figure>
       </div>
     </section>
@@ -178,27 +217,45 @@
       </div>
       <div class="gallery">
         <figure class="gallery-item" data-reveal>
-          <img src="images/ui/overview-v16.png?v=16" alt="Overview screen summarizing CPU, memory, thermal, cooling, power, network and storage." loading="lazy">
+          <a class="gallery-link" href="images/ui/overview-v16.png?v=16" data-lightbox="Overview" aria-label="Enlarge the Overview screenshot">
+            <img src="images/ui/overview-v16.png?v=16" alt="Overview screen summarizing CPU, memory, thermal, cooling, power, network and storage." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Overview</strong></figcaption>
         </figure>
         <figure class="gallery-item" data-reveal>
-          <img src="images/ui/cooling-v16.png?v=16" alt="Cooling screen with fan speeds, cooling mode and a custom fan curve editor." loading="lazy">
+          <a class="gallery-link" href="images/ui/cooling-v16.png?v=16" data-lightbox="Cooling" aria-label="Enlarge the Cooling screenshot">
+            <img src="images/ui/cooling-v16.png?v=16" alt="Cooling screen with fan speeds, cooling mode and a custom fan curve editor." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Cooling</strong></figcaption>
         </figure>
         <figure class="gallery-item" data-reveal>
-          <img src="images/ui/memory-v16.png?v=16" alt="Memory screen with usage history and a pressure breakdown." loading="lazy">
+          <a class="gallery-link" href="images/ui/memory-v16.png?v=16" data-lightbox="Memory" aria-label="Enlarge the Memory screenshot">
+            <img src="images/ui/memory-v16.png?v=16" alt="Memory screen with usage history and a pressure breakdown." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Memory</strong></figcaption>
         </figure>
         <figure class="gallery-item" data-reveal>
-          <img src="images/ui/storage-v16.png?v=16" alt="Storage screen with used, purgeable and free capacity." loading="lazy">
+          <a class="gallery-link" href="images/ui/storage-v16.png?v=16" data-lightbox="Storage" aria-label="Enlarge the Storage screenshot">
+            <img src="images/ui/storage-v16.png?v=16" alt="Storage screen with used, purgeable and free capacity." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Storage</strong></figcaption>
         </figure>
-        <figure class="gallery-item" data-reveal>
-          <img src="images/ui/menu-thermal-v16.png?v=16" alt="Thermal panel opened from the menu bar." loading="lazy">
+        <figure class="gallery-item is-tall" data-reveal>
+          <a class="gallery-link" href="images/ui/menu-thermal-v16.png?v=16" data-lightbox="Thermal panel" aria-label="Enlarge the Thermal panel screenshot">
+            <img src="images/ui/menu-thermal-v16.png?v=16" alt="Thermal panel opened from the menu bar." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Thermal panel</strong></figcaption>
         </figure>
-        <figure class="gallery-item" data-reveal>
-          <img src="images/ui/menu-network-v16.png?v=16" alt="Network panel opened from the menu bar." loading="lazy">
+        <figure class="gallery-item is-tall" data-reveal>
+          <a class="gallery-link" href="images/ui/menu-network-v16.png?v=16" data-lightbox="Network panel" aria-label="Enlarge the Network panel screenshot">
+            <img src="images/ui/menu-network-v16.png?v=16" alt="Network panel opened from the menu bar." loading="lazy" decoding="async">
+            <span class="gallery-zoom" aria-hidden="true"></span>
+          </a>
           <figcaption class="gallery-caption"><strong>Network panel</strong></figcaption>
         </figure>
       </div>
@@ -209,7 +266,7 @@
         <div class="feature-copy">
           <h2>Read only, until you decide otherwise</h2>
           <p>By default, Core-Monitor only watches the fans. Install the optional helper and you get three ways to drive them: a fixed speed, a boost profile, or a custom curve you draw yourself, point by point.</p>
-          <ol class="steps">
+          <ul class="steps">
             <li>
               <span class="step-body"><strong>Hand it back anytime</strong><span>One button returns full control to macOS, no restart needed.</span></span>
             </li>
@@ -220,12 +277,12 @@
               <span class="step-body"><strong>Skip the helper entirely</strong><span>Monitoring works identically whether or not it is installed.</span></span>
             </li>
             <li>
-              <span class="step-body"><strong>Calibrate first</strong><span>Measure each fan's real minimum and maximum before trusting a profile to it.</span></span>
+              <span class="step-body"><strong>Calibrate first</strong><span>Measure each fan&rsquo;s real minimum and maximum before trusting a profile to it.</span></span>
             </li>
-          </ol>
+          </ul>
         </div>
         <figure class="frame">
-          <img src="images/ui/cooling-v16.png?v=16" alt="Cooling screen showing two fans near 2,900 rpm, a custom curve mode, and a button that hands cooling back to macOS." loading="lazy">
+          <img src="images/ui/cooling-v16.png?v=16" alt="Cooling screen showing two fans near 2,900 rpm, a custom curve mode, and a button that hands cooling back to macOS." loading="lazy" decoding="async">
         </figure>
       </div>
     </section>
@@ -270,12 +327,13 @@
       </div>
       <div class="filmstrip">
         <figure class="reel" data-reveal>
-          <video controls preload="metadata" width="1280" height="720">
+          <video controls playsinline preload="metadata" width="1280" height="720" title="Core-Monitor Touch Bar widgets in use">
             <source src="videos/touchbar-showcase.mp4" type="video/mp4">
+            <p class="reel-fallback">Your browser cannot play this clip. <a href="videos/touchbar-showcase.mp4" download>Download the MP4</a> instead.</p>
           </video>
           <div class="reel-info">
             <strong>Widgets, overlays and shortcuts</strong>
-            Stats, weather, shortcuts and memory pressure, arranged with a live width preview so a layout never runs off the edge of the strip. The strip holds its place across apps, so you can check a reading or launch something without switching windows.
+            <p>Stats, weather, shortcuts and memory pressure, arranged with a live width preview so a layout never runs off the edge of the strip. The strip holds its place across apps, so you can check a reading or launch something without switching windows.</p>
           </div>
         </figure>
       </div>
@@ -283,11 +341,12 @@
 
     <section class="wrap section" id="compare">
       <div class="section-head">
-        <h2>How it stacks up</h2>
+        <h2 id="compare-title">How it stacks up</h2>
         <p>A handful of good Mac monitors already exist. This is where Core-Monitor sits next to them, stated plainly.</p>
       </div>
-      <div class="compare-wrap" data-reveal>
+      <div class="compare-wrap" data-reveal tabindex="0" role="region" aria-labelledby="compare-title">
         <table class="compare">
+          <caption>Written by the Core-Monitor developer. Check each app&rsquo;s own site for its current feature list.</caption>
           <thead>
             <tr>
               <th scope="col">App</th>
@@ -297,22 +356,22 @@
           </thead>
           <tbody>
             <tr>
-              <td>iStat Menus</td>
+              <th scope="row">iStat Menus</th>
               <td>Covers dozens of metrics across many menu bar modules.</td>
               <td>Narrower on purpose. Heat, power and fans, open source, with no license to buy.</td>
             </tr>
             <tr>
-              <td>TG Pro</td>
+              <th scope="row">TG Pro</th>
               <td>Deep per-sensor diagnostics.</td>
               <td>Monitoring comes first here; writing fan speed is an optional layer, not the whole app.</td>
             </tr>
             <tr>
-              <td>Macs Fan Control</td>
+              <th scope="row">Macs Fan Control</th>
               <td>Direct control over fan speed.</td>
               <td>Wraps that control in a full dashboard, with history, alerts and menu bar readouts.</td>
             </tr>
             <tr>
-              <td>Stats</td>
+              <th scope="row">Stats</th>
               <td>Free, modular menu bar widgets.</td>
               <td>One dedicated window with history, built specifically around thermals.</td>
             </tr>
@@ -354,6 +413,7 @@ brew install --cask offyotto/core-monitor/core-monitor</pre>
           </div>
         </article>
       </div>
+      <p class="visually-hidden" id="copy-status" role="status" aria-live="polite"></p>
     </section>
 
     <section class="wrap section" id="faq">
@@ -364,7 +424,7 @@ brew install --cask offyotto/core-monitor/core-monitor</pre>
       <div class="faq">
         <details class="faq-item" open>
           <summary class="faq-q">Which Macs can run it?<span class="faq-icon" aria-hidden="true"></span></summary>
-          <p>Apple Silicon Macs on macOS 13 or later. The sensors and fan interfaces it reads are specific to Apple's own chips, so Intel Macs are not supported.</p>
+          <p>Apple Silicon Macs on macOS 13 or later. The sensors and fan interfaces it reads are specific to Apple&rsquo;s own chips, so Intel Macs are not supported.</p>
         </details>
         <details class="faq-item">
           <summary class="faq-q">Do I need the helper installed?<span class="faq-icon" aria-hidden="true"></span></summary>
@@ -411,9 +471,17 @@ brew install --cask offyotto/core-monitor/core-monitor</pre>
         <a href="Mac-App-Store/support/">Support</a>
       </nav>
     </div>
+    <p class="wrap footer-legal">&copy; 2026 Nazish Faizan &middot; <a href="https://github.com/offyotto/Core-Monitor/blob/main/LICENSE">License</a></p>
   </footer>
 
-  <script src="https://unpkg.com/lenis@1.3.23/dist/lenis.min.js"></script>
-  <script src="script.js?v=6"></script>
+  <!-- Screenshot viewer. The gallery tiles are plain links to the full-size
+       image, so this is purely an enhancement. -->
+  <dialog class="lightbox" id="lightbox" aria-label="Screenshot viewer">
+    <img class="lightbox-img" alt="">
+    <div class="lightbox-bar">
+      <p class="lightbox-caption"></p>
+      <button class="lightbox-close" type="button" data-lightbox-close aria-label="Close screenshot">&times;</button>
+    </div>
+  </dialog>
 </body>
 </html>

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -1,0 +1,28 @@
+{
+  "name": "Core-Monitor",
+  "short_name": "Core-Monitor",
+  "description": "A free, open-source system monitor for Apple Silicon Macs. Temperature, CPU and GPU load, power draw, memory, battery and fan speed, read locally with optional fan control.",
+  "id": "/Core-Monitor/",
+  "start_url": "/Core-Monitor/",
+  "scope": "/Core-Monitor/",
+  "display": "minimal-ui",
+  "background_color": "#07080b",
+  "theme_color": "#07080b",
+  "lang": "en",
+  "dir": "ltr",
+  "categories": ["utilities", "productivity"],
+  "icons": [
+    {
+      "src": "images/site/core-monitor-logo.png?v=6",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "images/site/core-monitor-logo.png?v=6",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,124 +1,228 @@
-// Core-Monitor site behaviour: mobile nav, scroll reveal, clipboard copy,
-// and a slowed-down smooth scroll powered by Lenis.
+/* ==========================================================================
+   Core-Monitor site behaviour
+
+   Everything here is a progressive enhancement: the page is fully readable,
+   navigable and usable with this file blocked or broken. Notably the
+   scroll reveal animations are pure CSS now, so no content can ever be left
+   stuck at opacity 0 by a JavaScript failure.
+
+   No third-party libraries and no network requests.
+   ========================================================================== */
+
 (function () {
   "use strict";
 
-  var reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var doc = document;
 
-  function setupNav() {
-    var toggle = document.querySelector("[data-nav-toggle]");
-    var nav = document.querySelector("[data-nav]");
-    if (!toggle || !nav) return;
+  var closest = function (node, selector) {
+    return node && node.closest ? node.closest(selector) : null;
+  };
 
-    toggle.addEventListener("click", function () {
-      var open = !nav.classList.contains("is-open");
+  /* ---------- sticky header gets a shadow once you leave the top ---------- */
+
+  var header = doc.querySelector(".site-header");
+  if (header) {
+    var syncHeader = function () {
+      header.classList.toggle("is-scrolled", window.scrollY > 8);
+    };
+    syncHeader();
+    window.addEventListener("scroll", syncHeader, { passive: true });
+  }
+
+  /* ---------- mobile navigation ---------- */
+
+  var toggle = doc.querySelector(".nav-toggle");
+  var nav = doc.getElementById("primary-nav");
+
+  if (toggle && nav) {
+    var setNav = function (open) {
       nav.classList.toggle("is-open", open);
       toggle.setAttribute("aria-expanded", open ? "true" : "false");
+      toggle.setAttribute("aria-label", open ? "Close menu" : "Open menu");
+    };
+
+    var navIsOpen = function () {
+      return nav.classList.contains("is-open");
+    };
+
+    setNav(false);
+
+    toggle.addEventListener("click", function () {
+      setNav(!navIsOpen());
     });
 
-    nav.querySelectorAll("a").forEach(function (link) {
-      link.addEventListener("click", function () {
-        nav.classList.remove("is-open");
-        toggle.setAttribute("aria-expanded", "false");
-      });
+    // Tapping a section link should close the sheet behind you.
+    nav.addEventListener("click", function (event) {
+      if (closest(event.target, "a")) setNav(false);
+    });
+
+    doc.addEventListener("keydown", function (event) {
+      if (event.key === "Escape" && navIsOpen()) {
+        setNav(false);
+        toggle.focus();
+      }
+    });
+
+    doc.addEventListener("click", function (event) {
+      if (!navIsOpen()) return;
+      if (nav.contains(event.target) || toggle.contains(event.target)) return;
+      setNav(false);
     });
   }
 
-  function setupReveal() {
-    var items = document.querySelectorAll("[data-reveal]");
-    if (!items.length) return;
+  /* ---------- scroll spy: highlight the section you are reading ---------- */
 
-    if (reduceMotion || typeof IntersectionObserver === "undefined") {
-      items.forEach(function (el) { el.classList.add("is-visible"); });
-      return;
-    }
+  var navLinks = Array.prototype.slice.call(
+    doc.querySelectorAll('.primary-nav a[href^="#"]')
+  );
 
-    var watcher = new IntersectionObserver(
+  if (navLinks.length && "IntersectionObserver" in window) {
+    var linkFor = {};
+    var sections = [];
+
+    navLinks.forEach(function (link) {
+      var id = link.getAttribute("href").slice(1);
+      var section = id ? doc.getElementById(id) : null;
+      if (!section) return;
+      linkFor[id] = link;
+      sections.push(section);
+    });
+
+    var onScreen = {};
+
+    var paintCurrent = function () {
+      var current = null;
+      sections.forEach(function (section) {
+        if (!current && onScreen[section.id]) current = section.id;
+      });
+
+      navLinks.forEach(function (link) {
+        if (current && linkFor[current] === link) {
+          link.setAttribute("aria-current", "true");
+        } else {
+          link.removeAttribute("aria-current");
+        }
+      });
+    };
+
+    var spy = new IntersectionObserver(
       function (entries) {
         entries.forEach(function (entry) {
-          if (!entry.isIntersecting) return;
-          entry.target.classList.add("is-visible");
-          watcher.unobserve(entry.target);
+          onScreen[entry.target.id] = entry.isIntersecting;
         });
+        paintCurrent();
       },
-      { threshold: 0.2, rootMargin: "0px 0px -40px 0px" }
+      { rootMargin: "-30% 0px -60% 0px" }
     );
 
-    items.forEach(function (el, index) {
-      el.style.transitionDelay = Math.min(index % 6, 5) * 70 + "ms";
-      watcher.observe(el);
+    sections.forEach(function (section) {
+      spy.observe(section);
     });
   }
 
-  function setupCopyButtons() {
-    document.querySelectorAll("[data-copy]").forEach(function (button) {
-      var target = document.querySelector(button.getAttribute("data-copy"));
-      if (!target) return;
-      var restLabel = button.textContent;
+  /* ---------- copy-to-clipboard buttons ---------- */
+
+  var liveRegion = doc.getElementById("copy-status");
+
+  var announce = function (message) {
+    if (liveRegion) liveRegion.textContent = message;
+  };
+
+  Array.prototype.slice
+    .call(doc.querySelectorAll("[data-copy]"))
+    .forEach(function (button) {
+      var restingLabel = button.textContent;
+      var resetTimer = null;
+
+      var settle = function (ok) {
+        button.textContent = ok ? "Copied" : "Copy failed";
+        button.setAttribute("data-state", ok ? "done" : "failed");
+        announce(
+          ok
+            ? "Command copied to the clipboard."
+            : "Copying failed. Select the command and copy it manually."
+        );
+
+        window.clearTimeout(resetTimer);
+        resetTimer = window.setTimeout(function () {
+          button.textContent = restingLabel;
+          button.removeAttribute("data-state");
+          announce("");
+        }, 2400);
+      };
 
       button.addEventListener("click", function () {
-        var text = target.textContent.replace(/\s+\n/g, "\n").trim();
+        // data-copy holds a selector pointing at the block to copy, so the
+        // command itself lives in exactly one place: the markup people read.
+        var raw = button.getAttribute("data-copy") || "";
+        var text = raw;
 
-        function announce(label) {
-          button.textContent = label;
-          window.setTimeout(function () {
-            button.textContent = restLabel;
-          }, 1700);
+        if (raw.charAt(0) === "#") {
+          var source = doc.getElementById(raw.slice(1));
+          if (source) text = source.textContent;
         }
+
+        text = text.replace(/\s+$/, "");
 
         if (navigator.clipboard && navigator.clipboard.writeText) {
           navigator.clipboard.writeText(text).then(
-            function () { announce("Copied"); },
-            function () { announce("Copy failed"); }
+            function () {
+              settle(true);
+            },
+            function () {
+              settle(false);
+            }
           );
           return;
         }
 
-        var area = document.createElement("textarea");
-        area.value = text;
-        area.setAttribute("readonly", "");
-        area.style.position = "fixed";
-        area.style.opacity = "0";
-        document.body.appendChild(area);
-        area.select();
-        try {
-          document.execCommand("copy");
-          announce("Copied");
-        } catch (err) {
-          announce("Copy failed");
-        }
-        document.body.removeChild(area);
+        settle(false);
       });
     });
-  }
 
-  function setupSmoothScroll() {
-    if (reduceMotion) return;
-    if (typeof window.Lenis !== "function") return;
-    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) return;
+  /* ---------- screenshot lightbox ----------
+     The gallery tiles are ordinary links to the full-size image, so with
+     this disabled they still open the screenshot. When <dialog> is
+     available we intercept and show it in place instead. Escape, backdrop
+     clicks and focus restoration all come free from the dialog element. */
 
-    var lenis = new window.Lenis({
-      duration: 1.05,
-      easing: function (t) {
-        return Math.min(1, 1.001 - Math.pow(2, -10 * t));
-      },
-      autoRaf: true
+  var lightbox = doc.getElementById("lightbox");
+
+  if (lightbox && typeof lightbox.showModal === "function") {
+    var stage = lightbox.querySelector(".lightbox-img");
+    var stageCaption = lightbox.querySelector(".lightbox-caption");
+
+    doc.addEventListener("click", function (event) {
+      var trigger = closest(event.target, "[data-lightbox]");
+      if (!trigger) return;
+
+      // Let people open the raw image in a new tab if they mean to.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+      if (typeof event.button === "number" && event.button !== 0) return;
+
+      var thumb = trigger.querySelector("img");
+      event.preventDefault();
+
+      stage.setAttribute("src", trigger.getAttribute("href"));
+      stage.setAttribute("alt", thumb ? thumb.getAttribute("alt") || "" : "");
+      if (stageCaption) {
+        stageCaption.textContent = trigger.getAttribute("data-lightbox") || "";
+      }
+
+      lightbox.showModal();
     });
 
-    document.querySelectorAll('a[href^="#"]').forEach(function (link) {
-      link.addEventListener("click", function (event) {
-        var id = link.getAttribute("href").slice(1);
-        if (!id) return;
-        var dest = document.getElementById(id);
-        if (!dest) return;
-        event.preventDefault();
-        lenis.scrollTo(dest);
-      });
+    lightbox.addEventListener("click", function (event) {
+      if (
+        event.target === lightbox ||
+        closest(event.target, "[data-lightbox-close]")
+      ) {
+        lightbox.close();
+      }
+    });
+
+    lightbox.addEventListener("close", function () {
+      stage.removeAttribute("src");
     });
   }
-
-  setupNav();
-  setupReveal();
-  setupCopyButtons();
-  setupSmoothScroll();
 })();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,5 +1,6 @@
 /* ==========================================================================
    Core-Monitor site styles
+
    A rounded, native-feeling system built on macOS's own colour language:
    system blue for interactive elements and links, system orange for the
    thermal/heat theme, system green for "cool" states. Every colour is a
@@ -9,6 +10,11 @@
    can switch between a dark and a light chassis by swapping one block of
    variables. See the prefers-color-scheme: light block at the end of this
    file for the light variant; everything above it is the dark default.
+
+   Typography is 100% system fonts, so the site ships zero webfont requests
+   and nothing about a visitor reaches a third-party server. On macOS this
+   resolves to SF Pro / SF Mono. To go back to a webfont, set --font-display
+   below and re-add the stylesheet link in each page head.
    ========================================================================== */
 
 :root {
@@ -19,8 +25,8 @@
   --stroke: #262c35;
   --stroke-soft: #1a1f26;
   --text: #f1f3f6;
-  --text-dim: #9aa3b0;
-  --text-faint: #5c6572;
+  --text-dim: #a7b0bd;
+  --text-faint: #7d8796;
 
   --accent: #0a84ff;
   --accent-bright: #409cff;
@@ -31,27 +37,35 @@
   --volt: #32d74b;
   --volt-dim: #28b23d;
   --volt-ink: #04210b;
+  --volt-edge: rgba(50, 215, 75, 0.34);
   --link: var(--accent);
   --caution: #ffd60a;
   --danger: #ff453a;
   --header-glass: rgba(7, 8, 11, 0.88);
   --shadow-card: none;
+  --shadow-pop: 0 1px 2px rgba(0, 0, 0, 0.45), 0 22px 60px rgba(0, 0, 0, 0.55);
+  --scrim: rgba(4, 5, 7, 0.78);
 
   --radius-lg: 18px;
   --radius: 12px;
   --radius-sm: 9px;
 
-  --font-display: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Inter, Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Inter, Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
 
   --max: 1180px;
+  --header-h: 62px;
+
+  color-scheme: dark light;
 }
 
 * { box-sizing: border-box; }
 
 html {
   scroll-behavior: smooth;
+  /* Keeps anchored headings clear of the sticky header on every jump. */
+  scroll-padding-top: calc(var(--header-h) + 1.5rem);
   background: var(--ink);
 }
 
@@ -79,6 +93,7 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
+  border-radius: 4px;
 }
 
 img, video { max-width: 100%; height: auto; display: block; }
@@ -96,7 +111,8 @@ p:last-child { margin-bottom: 0; }
   width: 1px;
   height: 1px;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .skip-link {
@@ -109,7 +125,7 @@ p:last-child { margin-bottom: 0; }
   padding: 0.6rem 1rem;
   border-radius: var(--radius-sm);
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
 }
 .skip-link:focus { left: 1rem; }
 
@@ -120,11 +136,12 @@ p:last-child { margin-bottom: 0; }
   align-items: center;
   justify-content: center;
   gap: 0.55rem;
-  padding: 0.78rem 1.35rem;
+  min-height: 44px;
+  padding: 0.7rem 1.35rem;
   border-radius: var(--radius);
   border: 1px solid transparent;
   font-family: var(--font-body);
-  font-size: 0.94rem;
+  font-size: 0.96rem;
   font-weight: 600;
   letter-spacing: 0.005em;
   white-space: nowrap;
@@ -144,12 +161,20 @@ p:last-child { margin-bottom: 0; }
 .btn-ghost { color: var(--text-dim); }
 .btn-ghost:hover { color: var(--text); background: var(--panel); }
 
-.btn-sm { padding: 0.5rem 0.95rem; font-size: 0.85rem; }
+.btn-sm { min-height: 40px; padding: 0.45rem 0.95rem; font-size: 0.875rem; }
+
+@media (pointer: coarse) {
+  .btn-sm { min-height: 44px; }
+}
 
 .btn-group {
   display: flex;
   flex-wrap: wrap;
   gap: 0.7rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn, .btn:hover { transform: none; transition: none; }
 }
 
 /* ---------- header ---------- */
@@ -162,13 +187,20 @@ p:last-child { margin-bottom: 0; }
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border-bottom: 1px solid var(--stroke-soft);
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+/* Lifts the bar off the page once you start scrolling. */
+.site-header.is-scrolled {
+  border-bottom-color: var(--stroke);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 .header-row {
   display: flex;
   align-items: center;
   gap: 1.4rem;
-  padding: 0.9rem 0;
+  padding: 0.75rem 0;
 }
 
 .brand {
@@ -187,9 +219,9 @@ p:last-child { margin-bottom: 0; }
 .brand-text small {
   display: block;
   font-family: var(--font-mono);
-  font-size: 0.6rem;
+  font-size: 0.7rem;
   font-weight: 500;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-faint);
 }
@@ -197,13 +229,14 @@ p:last-child { margin-bottom: 0; }
 .nav-toggle {
   display: none;
   margin-left: auto;
-  width: 38px;
-  height: 34px;
+  width: 44px;
+  height: 44px;
   border: 1px solid var(--stroke);
   background: var(--panel);
   border-radius: var(--radius-sm);
   position: relative;
   cursor: pointer;
+  flex: none;
 }
 
 .nav-toggle span,
@@ -211,15 +244,17 @@ p:last-child { margin-bottom: 0; }
 .nav-toggle span::after {
   content: "";
   position: absolute;
-  left: 9px;
-  right: 9px;
+  left: 12px;
+  right: 12px;
   height: 1.5px;
   background: var(--text-dim);
   transition: transform 160ms ease, opacity 160ms ease;
 }
 .nav-toggle span { top: 50%; transform: translateY(-0.5px); }
-.nav-toggle span::before { top: -8px; }
-.nav-toggle span::after { top: 8px; }
+.nav-toggle span::before,
+.nav-toggle span::after { left: 0; right: 0; }
+.nav-toggle span::before { top: -7px; }
+.nav-toggle span::after { top: 7px; }
 
 .nav-toggle[aria-expanded="true"] span { background: transparent; }
 .nav-toggle[aria-expanded="true"] span::before { top: 0; transform: rotate(45deg); background: var(--accent); }
@@ -227,16 +262,31 @@ p:last-child { margin-bottom: 0; }
 
 .primary-nav {
   display: flex;
-  gap: 1.4rem;
+  gap: 1.35rem;
   margin-left: auto;
 }
 
 .primary-nav a {
+  position: relative;
   color: var(--text-dim);
-  font-size: 0.88rem;
+  font-size: 0.925rem;
   font-weight: 500;
+  padding: 0.25rem 0;
 }
 .primary-nav a:hover { color: var(--text); text-decoration: none; }
+
+/* Scroll spy: marks the section you are currently reading. */
+.primary-nav a[aria-current="true"] { color: var(--text); }
+.primary-nav a[aria-current="true"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--accent);
+}
 
 .header-actions {
   display: flex;
@@ -247,7 +297,10 @@ p:last-child { margin-bottom: 0; }
 
 .icon-link {
   display: inline-flex;
-  padding: 4px;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   color: var(--text-dim);
   border-radius: var(--radius-sm);
 }
@@ -259,7 +312,7 @@ p:last-child { margin-bottom: 0; }
 .hero {
   padding: 4.5rem 0 3.5rem;
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 6fr);
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 1fr);
   gap: 3rem;
   align-items: center;
 }
@@ -268,11 +321,11 @@ p:last-child { margin-bottom: 0; }
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
-  margin: 0 0 1.3rem;
+  margin: 0 0 1.25rem;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   font-weight: 500;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--text-dim);
 }
@@ -288,16 +341,17 @@ p:last-child { margin-bottom: 0; }
 .hero h1 {
   margin: 0 0 1.2rem;
   font-family: var(--font-display);
-  font-size: clamp(2.6rem, 5.6vw, 4rem);
-  font-weight: 600;
-  line-height: 1.06;
-  letter-spacing: -0.01em;
+  font-size: clamp(2.3rem, 4.6vw, 3.45rem);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.022em;
 }
 
 .mark {
   background: var(--volt);
   color: var(--volt-ink);
   padding: 0 0.15em;
+  border-radius: 4px;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
 }
@@ -309,7 +363,7 @@ p:last-child { margin-bottom: 0; }
   margin-bottom: 1.7rem;
 }
 
-.hero-actions { margin-bottom: 1.6rem; }
+.hero-actions { margin-bottom: 1.1rem; }
 
 .hero-visual { position: relative; }
 
@@ -322,7 +376,7 @@ p:last-child { margin-bottom: 0; }
   box-shadow: var(--shadow-card);
 }
 
-.frame img { border-radius: 12px; }
+.frame img { width: 100%; border-radius: 12px; }
 
 /* ---------- sections ---------- */
 
@@ -338,8 +392,8 @@ p:last-child { margin-bottom: 0; }
   margin: 0 0 0.75rem;
   font-family: var(--font-display);
   font-size: clamp(1.7rem, 3.2vw, 2.3rem);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-weight: 700;
+  letter-spacing: -0.018em;
   line-height: 1.15;
 }
 
@@ -356,6 +410,8 @@ p:last-child { margin-bottom: 0; }
   gap: 1.2rem;
 }
 
+.gallery-2up { grid-template-columns: repeat(2, 1fr); }
+
 .gallery-item {
   margin: 0;
   border: 1px solid var(--stroke);
@@ -367,6 +423,19 @@ p:last-child { margin-bottom: 0; }
 }
 
 .gallery-item:hover { border-color: var(--text-faint); transform: translateY(-3px); }
+.gallery-item:focus-within { border-color: var(--accent); }
+
+.gallery-link {
+  display: block;
+  position: relative;
+  cursor: zoom-in;
+}
+.gallery-link:hover { text-decoration: none; }
+
+.gallery-item.is-tall img {
+  object-fit: contain;
+  background: var(--panel);
+}
 
 .gallery-item img {
   width: 100%;
@@ -378,12 +447,98 @@ p:last-child { margin-bottom: 0; }
 
 .gallery-item:hover img { transform: scale(1.03); }
 
+/* Tiny affordance so it reads as "click to enlarge". */
+.gallery-zoom {
+  position: absolute;
+  right: 0.7rem;
+  bottom: 0.7rem;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--scrim);
+  border: 1px solid var(--stroke);
+  opacity: 0;
+  transition: opacity 180ms ease;
+}
+.gallery-zoom::before,
+.gallery-zoom::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  background: #ffffff;
+  transform: translate(-50%, -50%);
+}
+.gallery-zoom::before { width: 12px; height: 1.5px; }
+.gallery-zoom::after { width: 1.5px; height: 12px; }
+
+.gallery-item:hover .gallery-zoom,
+.gallery-item:focus-within .gallery-zoom { opacity: 1; }
+
 .gallery-caption {
   padding: 0.85rem 1rem;
   border-top: 1px solid var(--stroke-soft);
 }
 
-.gallery-caption strong { font-size: 0.94rem; font-weight: 600; }
+.gallery-caption strong { font-size: 0.95rem; font-weight: 600; }
+
+@media (prefers-reduced-motion: reduce) {
+  .gallery-item, .gallery-item:hover,
+  .gallery-item img, .gallery-item:hover img { transform: none; transition: none; }
+}
+
+/* ---------- lightbox ---------- */
+
+.lightbox {
+  width: min(1180px, calc(100vw - 2.5rem));
+  max-width: none;
+  max-height: calc(100vh - 2.5rem);
+  padding: 0;
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+  color: var(--text);
+  box-shadow: var(--shadow-pop);
+  overflow: hidden;
+}
+.lightbox::backdrop { background: rgba(3, 4, 6, 0.82); }
+.lightbox:not([open]) { display: none; }
+
+.lightbox-img {
+  width: 100%;
+  max-height: calc(100vh - 9rem);
+  object-fit: contain;
+  background: var(--panel-soft);
+}
+
+.lightbox-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0.8rem 0.8rem 1.15rem;
+  border-top: 1px solid var(--stroke-soft);
+}
+
+.lightbox-caption {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.lightbox-close {
+  flex: none;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--stroke);
+  background: none;
+  color: var(--text-dim);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.lightbox-close:hover { color: var(--text); border-color: var(--text-faint); background: var(--panel-raised); }
 
 /* ---------- feature split (cooling) ---------- */
 
@@ -398,8 +553,8 @@ p:last-child { margin-bottom: 0; }
   margin: 0 0 0.9rem;
   font-family: var(--font-display);
   font-size: clamp(1.7rem, 3.2vw, 2.3rem);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-weight: 700;
+  letter-spacing: -0.018em;
   line-height: 1.15;
 }
 
@@ -415,10 +570,31 @@ p:last-child { margin-bottom: 0; }
 
 .steps li {
   display: flex;
+  gap: 0.85rem;
+}
+
+/* These points are parallel guarantees, not an ordered procedure, so the
+   list is unordered and each item is marked with a check rather than a
+   number that would imply a sequence. */
+.steps li::before {
+  content: "\2713";
+  flex: none;
+  width: 25px;
+  height: 25px;
+  margin-top: 0.15rem;
+  border-radius: 8px;
+  background: var(--panel-raised);
+  border: 1px solid var(--stroke);
+  color: var(--volt);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1;
+  display: grid;
+  place-items: center;
 }
 
 .step-body strong { display: block; color: var(--text); font-weight: 600; margin-bottom: 0.15rem; }
-.step-body span { color: var(--text-dim); font-size: 0.94rem; }
+.step-body span { color: var(--text-dim); font-size: 0.95rem; }
 
 /* ---------- scenario cards ---------- */
 
@@ -439,14 +615,21 @@ p:last-child { margin-bottom: 0; }
 
 .card:hover { border-color: var(--text-faint); transform: translateY(-3px); }
 
-.card h3 { margin: 0 0 0.5rem; font-size: 1.05rem; font-weight: 600; letter-spacing: -0.005em; }
-.card p { margin: 0; font-size: 0.95rem; color: var(--text-dim); }
+/* "is-cool" cards are the ones about handing heat back under control. */
+.card.is-cool { border-color: var(--volt-edge); }
+.card.is-cool:hover { border-color: var(--volt); }
 
-/* ---------- filmstrip (touch bar videos) ---------- */
+.card h3 { margin: 0 0 0.5rem; font-size: 1.06rem; font-weight: 600; letter-spacing: -0.005em; }
+.card p { margin: 0; font-size: 0.96rem; color: var(--text-dim); }
+
+@media (prefers-reduced-motion: reduce) {
+  .card, .card:hover { transform: none; transition: none; }
+}
+
+/* ---------- filmstrip (touch bar video) ---------- */
 
 .filmstrip {
   display: grid;
-  max-width: 46rem;
 }
 
 .reel {
@@ -458,16 +641,18 @@ p:last-child { margin-bottom: 0; }
   box-shadow: var(--shadow-card);
 }
 
-.reel video { width: 100%; display: block; }
+.reel video { width: 100%; display: block; background: var(--panel-soft); }
 
 .reel-info {
   padding: 1rem 1.1rem;
   border-top: 1px solid var(--stroke-soft);
   color: var(--text-dim);
-  font-size: 0.92rem;
+  font-size: 0.94rem;
 }
 
 .reel-info strong { display: block; color: var(--text); font-weight: 600; margin-bottom: 0.25rem; }
+
+.reel-fallback { margin: 0.6rem 0 0; font-size: 0.9rem; }
 
 /* ---------- comparison table ---------- */
 
@@ -479,11 +664,25 @@ p:last-child { margin-bottom: 0; }
   box-shadow: var(--shadow-card);
 }
 
+.compare-wrap:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .compare {
   width: 100%;
   min-width: 640px;
   border-collapse: collapse;
   background: var(--panel);
+}
+
+.compare caption {
+  caption-side: bottom;
+  padding: 0.85rem 1.3rem;
+  border-top: 1px solid var(--stroke-soft);
+  text-align: left;
+  font-size: 0.85rem;
+  color: var(--text-faint);
 }
 
 .compare th, .compare td {
@@ -497,15 +696,15 @@ p:last-child { margin-bottom: 0; }
   border-top: 0;
   background: var(--panel-soft);
   font-family: var(--font-mono);
-  font-size: 0.62rem;
-  font-weight: 500;
-  letter-spacing: 0.14em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--text-faint);
+  color: var(--text-dim);
 }
 
-.compare td:first-child { font-weight: 600; white-space: nowrap; color: var(--text); }
-.compare td { font-size: 0.93rem; color: var(--text-dim); }
+.compare tbody th { font-weight: 600; white-space: nowrap; color: var(--text); }
+.compare td { font-size: 0.95rem; color: var(--text-dim); }
 .compare tbody tr:hover { background: var(--panel-raised); }
 
 /* ---------- install routes ---------- */
@@ -527,8 +726,8 @@ p:last-child { margin-bottom: 0; }
   box-shadow: var(--shadow-card);
 }
 
-.route h3 { margin: 0; font-size: 1.08rem; font-weight: 600; }
-.route > p { margin: 0; font-size: 0.94rem; color: var(--text-dim); flex-grow: 1; }
+.route h3 { margin: 0; font-size: 1.1rem; font-weight: 600; }
+.route > p { margin: 0; font-size: 0.96rem; color: var(--text-dim); flex-grow: 1; }
 .route-actions { display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; }
 
 .code-block {
@@ -538,32 +737,39 @@ p:last-child { margin-bottom: 0; }
   border: 1px solid var(--stroke-soft);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
-  font-size: 0.74rem;
-  line-height: 1.55;
-  color: var(--text-dim);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--text);
   overflow-x: auto;
   white-space: pre;
+  tab-size: 2;
 }
 
 .copy-btn {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
   border: 1px solid var(--stroke);
   border-radius: var(--radius-sm);
   background: none;
   color: var(--text-dim);
   font-family: var(--font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.4rem 0.7rem;
+  padding: 0.4rem 0.85rem;
   cursor: pointer;
   transition: color 140ms ease, border-color 140ms ease;
 }
 .copy-btn:hover { color: var(--text); border-color: var(--text-faint); }
+.copy-btn[data-state="done"] { color: var(--volt); border-color: var(--volt-edge); }
+.copy-btn[data-state="failed"] { color: var(--danger); border-color: var(--danger); }
+
+.route-note { margin: 0; font-size: 0.875rem; color: var(--text-faint); }
 
 /* ---------- faq ---------- */
 
 .faq {
-  max-width: 44rem;
   background: var(--panel);
   border: 1px solid var(--stroke);
   border-radius: var(--radius-lg);
@@ -582,10 +788,11 @@ p:last-child { margin-bottom: 0; }
   padding: 1.2rem 0;
   cursor: pointer;
   font-weight: 600;
-  font-size: 1.02rem;
+  font-size: 1.03rem;
   list-style: none;
 }
 .faq-q::-webkit-details-marker { display: none; }
+.faq-q:hover { color: var(--accent-bright); }
 
 .faq-icon {
   position: relative;
@@ -608,7 +815,7 @@ p:last-child { margin-bottom: 0; }
 .faq-item p {
   margin: 0 0 1.3rem;
   max-width: 40rem;
-  font-size: 0.96rem;
+  font-size: 0.97rem;
   color: var(--text-dim);
 }
 
@@ -634,12 +841,14 @@ p:last-child { margin-bottom: 0; }
   max-width: 30rem;
   font-family: var(--font-display);
   font-size: clamp(1.7rem, 3.4vw, 2.4rem);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-weight: 700;
+  letter-spacing: -0.018em;
   line-height: 1.2;
 }
 
 /* ---------- footer ---------- */
+
+.btn.btn-ghost { padding-inline: 0.55rem; }
 
 .site-footer {
   border-top: 1px solid var(--stroke-soft);
@@ -667,10 +876,11 @@ p:last-child { margin-bottom: 0; }
   flex-wrap: wrap;
   gap: 1.2rem;
 }
-.footer-nav a { color: var(--text-dim); font-size: 0.87rem; }
+.footer-nav a { color: var(--text-dim); font-size: 0.925rem; }
 .footer-nav a:hover { color: var(--text); }
 
-
+.footer-legal { margin: 1.6rem 0 0; font-size: 0.875rem; color: var(--text-faint); }
+.footer-legal a { color: inherit; }
 
 /* ---------- subpages ---------- */
 
@@ -680,8 +890,8 @@ p:last-child { margin-bottom: 0; }
   margin: 0 0 1rem;
   font-family: var(--font-display);
   font-size: clamp(2.1rem, 4.6vw, 3.2rem);
-  font-weight: 600;
-  letter-spacing: -0.01em;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   line-height: 1.08;
 }
 
@@ -690,8 +900,8 @@ p:last-child { margin-bottom: 0; }
 .meta-line {
   margin: 0 0 0.4rem;
   font-family: var(--font-mono);
-  font-size: 0.76rem;
-  letter-spacing: 0.02em;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
   color: var(--text-faint);
 }
 
@@ -709,7 +919,7 @@ p:last-child { margin-bottom: 0; }
   box-shadow: var(--shadow-card);
 }
 
-.ledger-col h3 { margin: 0 0 1rem; font-size: 1.04rem; font-weight: 600; }
+.ledger-col h3 { margin: 0 0 1rem; font-size: 1.05rem; font-weight: 600; }
 
 .ledger-col ul {
   list-style: none;
@@ -723,7 +933,7 @@ p:last-child { margin-bottom: 0; }
   display: flex;
   gap: 0.75rem;
   align-items: baseline;
-  font-size: 0.94rem;
+  font-size: 0.96rem;
   color: var(--text-dim);
 }
 
@@ -755,32 +965,49 @@ p:last-child { margin-bottom: 0; }
   margin: 0;
   font-family: var(--font-display);
   font-size: clamp(3.2rem, 10vw, 6.5rem);
-  font-weight: 600;
-  letter-spacing: -0.02em;
+  font-weight: 700;
+  letter-spacing: -0.03em;
   line-height: 1;
 }
 
 .void p { margin: 0; color: var(--text-dim); max-width: 30rem; }
 
-/* ---------- motion ---------- */
+/* ---------- motion ----------
+   Reveal-on-scroll is pure CSS. Browsers with scroll-driven animation
+   support tie the fade to the element entering the viewport; everywhere
+   else it degrades to one gentle fade as the page loads. Either way the
+   content is never left invisible, which is the risk an opacity:0 plus
+   IntersectionObserver setup carries if its script fails to run.
 
-[data-reveal] {
-  opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 560ms ease, transform 560ms ease;
+   The keyframes move the element with `translate`, not `transform`, so the
+   hover lift on cards and gallery tiles keeps working after the animation
+   has finished and filled forwards. */
+
+@keyframes reveal-in {
+  from { opacity: 0; translate: 0 16px; }
+  to { opacity: 1; translate: none; }
 }
-[data-reveal].is-visible { opacity: 1; transform: none; }
+
+[data-reveal] { animation: reveal-in 620ms ease both; }
+
+@supports (animation-timeline: view()) {
+  [data-reveal] {
+    animation: reveal-in linear both;
+    animation-timeline: view();
+    animation-range: entry 4% cover 20%;
+  }
+}
 
 @media (prefers-reduced-motion: reduce) {
-  [data-reveal] { opacity: 1; transform: none; transition: none; }
+  [data-reveal] { animation: none; }
 }
 
 /* ---------- responsive ---------- */
 
 @media (max-width: 980px) {
-  .hero { grid-template-columns: 1fr; gap: 2.4rem; padding-top: 2.6rem; }
-  .gallery, .cards, .routes { grid-template-columns: 1fr 1fr; }
-  .feature { grid-template-columns: 1fr; gap: 2rem; }
+  .hero { grid-template-columns: minmax(0, 1fr); gap: 2.4rem; padding-top: 2.6rem; }
+  .gallery, .cards, .routes { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+  .feature { grid-template-columns: minmax(0, 1fr); gap: 2rem; }
   .header-row { flex-wrap: wrap; }
   .nav-toggle { display: block; margin-left: auto; }
   .primary-nav {
@@ -789,22 +1016,40 @@ p:last-child { margin-bottom: 0; }
     flex-direction: column;
     gap: 0;
     order: 3;
+    margin-left: 0;
   }
   .primary-nav.is-open {
     display: flex;
     border-top: 1px solid var(--stroke-soft);
     margin-top: 0.9rem;
-    padding-top: 0.6rem;
+    padding-top: 0.4rem;
   }
-  .primary-nav a { padding: 0.6rem 0; }
+  .primary-nav a { padding: 0.7rem 0; }
+  .primary-nav a[aria-current="true"]::after { display: none; }
 }
 
 @media (max-width: 640px) {
   body { font-size: 1rem; }
-  .gallery, .cards, .routes, .ledger { grid-template-columns: 1fr; }
+  .wrap { width: min(var(--max), calc(100% - 2.5rem)); }
+  .gallery, .gallery-2up, .cards, .routes, .ledger { grid-template-columns: minmax(0, 1fr); }
   .filmstrip { max-width: none; }
   .section { padding: 3.6rem 0; }
   .cta-inner { padding: 3rem 0; }
+  .hero { padding-bottom: 2.5rem; }
+  .header-actions { gap: 0.5rem; }
+  .header-actions .icon-link { display: none; }
+  .btn-group .btn { flex: 1 1 auto; }
+  .lightbox { width: calc(100vw - 1.25rem); }
+}
+
+/* ---------- print ---------- */
+
+@media print {
+  .site-header, .cta, .nav-toggle, .gallery-zoom, .lightbox { display: none !important; }
+  body { background: #ffffff; color: #000000; font-size: 11pt; }
+  a { color: #000000; text-decoration: underline; }
+  .card, .route, .ledger-col, .faq, .compare-wrap, .frame { border-color: #cccccc; box-shadow: none; }
+  [data-reveal] { animation: none !important; opacity: 1 !important; translate: none !important; }
 }
 
 /* ---------- light chassis ----------
@@ -819,26 +1064,35 @@ p:last-child { margin-bottom: 0; }
   :root {
     --ink: #f1f2ef;
     --panel: #ffffff;
-    --panel-raised: #ffffff;
+    --panel-raised: #f7f8f5;
     --panel-soft: #e8eae4;
     --stroke: #d9dbd4;
     --stroke-soft: #e6e8e1;
     --text: #14171a;
-    --text-dim: #52565c;
-    --text-faint: #666b70;
+    --text-dim: #4a4e54;
+    --text-faint: #55595e;
 
-    --accent: #007aff;
-    --accent-bright: #0064d6;
-    --signal: #ff9500;
-    --signal-bright: #e2830a;
-    --volt: #34c759;
+    --accent: #0069d9;
+    --accent-bright: #0058b8;
+    --signal: #b35c00;
+    --signal-bright: #995000;
+    --volt: #248a3d;
+    --volt-edge: rgba(36, 138, 61, 0.4);
+    --danger: #c9271c;
     --header-glass: rgba(241, 242, 239, 0.86);
     --shadow-card: 0 1px 2px rgba(20, 23, 26, 0.06), 0 14px 28px rgba(20, 23, 26, 0.08);
+    --shadow-pop: 0 1px 2px rgba(20, 23, 26, 0.1), 0 24px 60px rgba(20, 23, 26, 0.22);
+    --scrim: rgba(20, 23, 26, 0.62);
   }
 
   body {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='26' height='26'%3E%3Ccircle cx='1.3' cy='1.3' r='1.3' fill='%23e1e3dd'/%3E%3C/svg%3E");
   }
 
-  ::selection { background: rgba(0, 122, 255, 0.22); }
+  /* The green highlight needs dark ink on it in light mode. */
+  .mark { background: #34c759; color: #04210b; }
+
+  .site-header.is-scrolled { box-shadow: 0 10px 30px rgba(20, 23, 26, 0.09); }
+
+  ::selection { background: rgba(0, 105, 217, 0.2); }
 }


### PR DESCRIPTION
Two passes on `docs/`. The first was performance and accessibility. The second removed the decorative chrome and the patterns that read as machine-generated frontend.

## Pass 2 — badges, chrome, and AI tells

### Removed

| Removed | Why |
| --- | --- |
| Eyebrow chip above the headline (`Free · Open source · Apple silicon`) | The small pill of dot-separated words above an H1 is one of the most recognizable tells in current AI-generated layouts. |
| Monospace spec strip under the hero buttons (`macOS 13 or later · Apple silicon · About 5 MB`) | Same pattern as the stat banner (`500K Users · 50M Downloads · 99.9% Uptime`). Requirements are already answered properly in the FAQ. |
| Green highlighter behind the second half of the headline | Decoration carrying no meaning. The words are untouched; only the background is gone. |
| Uniform fade-up on all 17 sections | An identical `opacity: 0 → 1, y: 20 → 0` on every block is the single most common generated-site motion signature. Also removes the keyframes, the `animation-timeline: view()` branch, and two reduced-motion guards. |
| Hover magnifier badges on the six gallery tiles | Icon-in-a-circle-on-hover decoration. The tiles are already links with `cursor: zoom-in`. |
| Checkmark tiles on the cooling list | Green rounded checkmark squares next to benefit text. Replaced with a plain neutral dot. |
| Lift-on-hover for the six scenario cards | These are `<article>` elements, not links. The lift implied an interaction that does not exist — a UX lie independent of the styling question. |

### Also cleaned up

- Dead light-theme rule for the deleted highlighter
- Print stylesheet still hiding the deleted gallery badge
- The orphaned `transition` on `.card` and its now-pointless reduced-motion guard
- Two comments describing rules that no longer exist

### Deliberately not changed

None of the page copy was rewritten. The writing is specific to this app — "Where people actually reach for it", "Three doors, same app", "Narrower on purpose" — which is the opposite of the generated-copy pattern, where a headline could describe any product. Rewriting it would have introduced the problem this pass was meant to remove.

Also left alone, as judgement calls rather than defects: the monospace table headers and copy button label (a consistent choice across code-adjacent UI on a developer tool), the sticky header's `backdrop-filter` (a real layering need), and the green borders on the two "cooling" cards.

## Pass 1 — performance, accessibility, SEO

- Dropped every third-party request: two Google Fonts stylesheets, the `fonts.gstatic.com` preconnect, and the Lenis smooth-scroll CSS + JS from unpkg. Type is now the system UI stack, so no visitor data reaches another origin.
- Added a strict `Content-Security-Policy` that the page actually satisfies.
- Skip link, focus-visible rings, a keyboard-scrollable comparison table with an accessible name, 44px minimum touch targets, and `aria-current` on the active nav item.
- Preload + `fetchpriority="high"` on the LCP screenshot; intrinsic `width`/`height` on images to stop layout shift.
- Light mode via `prefers-color-scheme`, built entirely from custom properties.
- Full `prefers-reduced-motion` coverage.
- `manifest.webmanifest`, canonical URL, Open Graph and Twitter tags, and a JSON-LD `@graph` with WebSite, SoftwareApplication and FAQPage nodes.

## Verification

Headless Chromium against a local server, dark and light, desktop and mobile, plus a JS-disabled run: 0 console/CSP errors, 0 missing resources, 0 remaining third-party references. `script.js` and `manifest.webmanifest` are unchanged in pass 2; the stylesheet cache key is now `v=17`.

## Follow-up not in this PR

`404.html` and the three `Mac-App-Store/` pages still carry the same chrome (they share `.meta-line`, and may still have reveal hooks). Worth a matching pass.