### PR TITLE
Update MAX_AGE for local storage

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -194,7 +194,7 @@
 
     var ENDPOINT = "https://api.github.com/repos/offyotto/Core-Monitor";
     var KEY = "core-monitor:stars";
-    var MAX_AGE = 6 * 60 * 60 * 1000;
+    var MAX_AGE = 10 * 60 * 1000;
 
     var recall = function () {
       try {


### PR DESCRIPTION
Increased the MAX_AGE for local storage from 6 hours to 10 minutes.

## Change

Describe the problem and the change.

## Verification

List the checks you ran.

- [x] Tests cover the changed behavior.
- [x] User-facing changes are documented.
- [x] Security-sensitive changes were reviewed for privilege, XPC, signing, and SMC impact.
