### PR TITLE
Clarify Mac App Store availability

### DIFF
--- a/docs/Mac-App-Store/index.html
+++ b/docs/Mac-App-Store/index.html
@@ -3,29 +3,28 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Core-Monitor on the Mac App Store | Read-Only Edition for macOS</title>
-  <meta name="description" content="The Mac App Store edition of Core-Monitor: a sandboxed, read-only system monitor for macOS with CPU, memory, storage, battery, network, thermal state, a menu bar extra, and optional local weather.">
+  <title>Core-Monitor Is Available on the Mac App Store | macOS</title>
+  <meta name="description" content="Core-Monitor is available free on the Mac App Store at Apple app ID 6762558526. The sandboxed macOS edition monitors CPU, memory, storage, battery, network, and thermal state.">
   <meta name="application-name" content="Core-Monitor">
   <meta name="apple-mobile-web-app-title" content="Core-Monitor">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <meta name="theme-color" content="#07080b" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#f1f2ef" media="(prefers-color-scheme: light)">
   <link rel="canonical" href="https://offyotto.github.io/Core-Monitor/Mac-App-Store/">
-  <link rel="alternate" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">
   <link rel="icon" href="../favicon.ico?v=6" sizes="any">
   <link rel="icon" type="image/png" sizes="512x512" href="../images/site/core-monitor-logo.png?v=6">
   <link rel="shortcut icon" href="../images/site/core-monitor-logo.png?v=6">
   <link rel="apple-touch-icon" href="../images/site/core-monitor-logo.png?v=6">
   <meta property="og:site_name" content="Core-Monitor">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Core-Monitor on the Mac App Store | Read-Only Edition for macOS">
-  <meta property="og:description" content="The sandboxed, read-only edition of Core-Monitor, reviewed and delivered by Apple.">
+  <meta property="og:title" content="Core-Monitor Is Available on the Mac App Store">
+  <meta property="og:description" content="Download the free, sandboxed macOS edition of Core-Monitor from Apple.">
   <meta property="og:url" content="https://offyotto.github.io/Core-Monitor/Mac-App-Store/">
   <meta property="og:image" content="https://offyotto.github.io/Core-Monitor/images/ui/mac-app-store/app-store-dashboard.png">
   <meta property="og:image:alt" content="Core-Monitor Mac App Store edition dashboard with CPU, memory, thermal state and weather cards.">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Core-Monitor on the Mac App Store">
-  <meta name="twitter:description" content="The sandboxed, read-only edition of Core-Monitor for macOS.">
+  <meta name="twitter:description" content="Core-Monitor is available free on the Mac App Store.">
   <meta name="twitter:image" content="https://offyotto.github.io/Core-Monitor/images/ui/mac-app-store/app-store-dashboard.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,26 +38,29 @@
       {
         "@type": "WebPage",
         "@id": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/#webpage",
-        "name": "Core-Monitor Mac App Store Edition",
+        "name": "Core-Monitor Is Available on the Mac App Store",
         "url": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/",
-        "description": "The Mac App Store edition of Core-Monitor, with a direct link to the Apple listing.",
+        "description": "Core-Monitor is available free on the Mac App Store at Apple app ID 6762558526.",
         "about": { "@id": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/#app" }
       },
       {
         "@type": "SoftwareApplication",
         "@id": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/#app",
         "name": "Core-Monitor",
-        "alternateName": ["Core Monitor", "Core-Monitor Mac App Store"],
+        "alternateName": ["Core Monitor", "Core-Monitor for Mac"],
         "operatingSystem": "macOS 14 or later",
         "applicationCategory": "UtilitiesApplication",
         "softwareRequirements": "Mac with macOS 14 or later",
-        "description": "Core-Monitor on the Mac App Store is a sandboxed, read-only system monitor showing CPU activity, memory pressure, storage, battery, network, thermal state, a menu bar extra, and optional local weather.",
-        "url": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/",
-        "downloadUrl": "https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12",
+        "description": "Core-Monitor is available free on the Mac App Store as a sandboxed, read-only system monitor showing CPU activity, memory pressure, storage, battery, network, thermal state, a menu bar extra, and optional local weather.",
+        "url": "https://apps.apple.com/us/app/core-monitor/id6762558526",
         "installUrl": "https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12",
+        "identifier": "6762558526",
+        "softwareVersion": "2.0",
+        "datePublished": "2026-04-28",
+        "codeRepository": "https://github.com/offyotto/core-monitor-app-store",
         "sameAs": [
-          "https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12",
-          "https://offyotto.github.io/Core-Monitor/Mac-App-Store/"
+          "https://apps.apple.com/us/app/core-monitor/id6762558526",
+          "https://github.com/offyotto/core-monitor-app-store"
         ],
         "isAccessibleForFree": true,
         "featureList": [
@@ -68,7 +70,13 @@
           "Menu bar extra with a live summary",
           "Local weather when location access is granted"
         ],
-        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+          "availability": "https://schema.org/OnlineOnly",
+          "url": "https://apps.apple.com/us/app/core-monitor/id6762558526"
+        },
         "developer": { "@type": "Person", "name": "Nazish Faizan" }
       }
     ]
@@ -100,8 +108,8 @@
 
   <main id="main">
     <section class="wrap intro">
-      <h1>The same monitor, kept inside Apple's sandbox</h1>
-      <p class="hero-text">This build of Core-Monitor is reviewed and delivered by Apple. It reads and displays; it never writes to hardware. If fan control matters to you, the <a href="../">direct download</a> is the build to use instead.</p>
+      <h1>Core-Monitor is available on the Mac App Store</h1>
+      <p class="hero-text">Core-Monitor is listed as a free macOS app at Apple app ID 6762558526. Apple reviews, signs and delivers this sandboxed edition. It reads and displays system data but does not write to hardware. If fan control matters to you, the <a href="../">direct download</a> is the build to use instead.</p>
       <div class="btn-group">
         <a class="btn btn-solid" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">Open the Apple listing</a>
         <a class="btn btn-outline" href="#scope">What is in this edition</a>

--- a/docs/Mac-App-Store/privacy/index.html
+++ b/docs/Mac-App-Store/privacy/index.html
@@ -11,7 +11,6 @@
   <meta name="theme-color" content="#07080b" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#f1f2ef" media="(prefers-color-scheme: light)">
   <link rel="canonical" href="https://offyotto.github.io/Core-Monitor/Mac-App-Store/privacy/">
-  <link rel="alternate" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">
   <link rel="icon" href="../../favicon.ico?v=6" sizes="any">
   <link rel="icon" type="image/png" sizes="512x512" href="../../images/site/core-monitor-logo.png?v=6">
   <link rel="shortcut icon" href="../../images/site/core-monitor-logo.png?v=6">

--- a/docs/Mac-App-Store/support/index.html
+++ b/docs/Mac-App-Store/support/index.html
@@ -11,7 +11,6 @@
   <meta name="theme-color" content="#07080b" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#f1f2ef" media="(prefers-color-scheme: light)">
   <link rel="canonical" href="https://offyotto.github.io/Core-Monitor/Mac-App-Store/support/">
-  <link rel="alternate" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">
   <link rel="icon" href="../../favicon.ico?v=6" sizes="any">
   <link rel="icon" type="image/png" sizes="512x512" href="../../images/site/core-monitor-logo.png?v=6">
   <link rel="shortcut icon" href="../../images/site/core-monitor-logo.png?v=6">

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,14 +89,9 @@
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "license": "https://github.com/offyotto/Core-Monitor/blob/main/LICENSE",
         "codeRepository": "https://github.com/offyotto/Core-Monitor",
-        "softwareHelp": {
-          "@type": "CreativeWork",
-          "url": "https://offyotto.github.io/Core-Monitor/Mac-App-Store/support/"
-        },
         "sameAs": [
           "https://github.com/offyotto/Core-Monitor",
-          "https://github.com/offyotto/Core-Monitor/releases",
-          "https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12"
+          "https://github.com/offyotto/Core-Monitor/releases"
         ],
         "developer": { "@type": "Person", "name": "offyotto", "url": "https://github.com/offyotto" }
       },
@@ -377,7 +372,7 @@
 
     <section class="wrap section" id="install">
       <div class="section-head">
-        <h2>Three doors, same app</h2>
+        <h2>Two editions, three install options</h2>
         <p>Pick whichever matches how you manage software on your Mac. Every route below is free.</p>
       </div>
       <div class="routes">
@@ -401,7 +396,7 @@ brew install --cask offyotto/core-monitor/core-monitor</pre>
         </article>
         <article class="route">
           <h3>Take the sandboxed edition</h3>
-          <p>A read-only build reviewed by Apple. No helper and no fan writes, exactly as the App Store requires.</p>
+          <p>Core-Monitor is available free on the Mac App Store as a read-only build reviewed and delivered by Apple. It has no helper or fan writes.</p>
           <div class="route-actions">
             <a class="btn btn-outline btn-sm" href="Mac-App-Store/">About this edition</a>
             <a class="btn btn-ghost btn-sm" href="https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12">Open listing</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,6 +9,8 @@ Primary download: https://github.com/offyotto/Core-Monitor/releases/latest/downl
 Mac App Store listing: https://apps.apple.com/us/app/core-monitor/id6762558526?mt=12
 Mac App Store edition page: https://offyotto.github.io/Core-Monitor/Mac-App-Store/
 
+Core-Monitor is available on the Mac App Store as Apple app ID 6762558526.
+
 ## Summary
 
 - Category: macOS utility, system monitor, thermal monitor, fan control

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,26 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/Mac-App-Store/</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/Mac-App-Store/support/</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/Mac-App-Store/privacy/</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/llms.txt</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-12</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/llms-full.txt</loc>
-    <lastmod>2026-06-29</lastmod>
+    <lastmod>2026-08-09</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
The direct and Mac App Store editions were linked as the same software entity, while the App Store page did not state availability in its main heading. Search systems could combine the direct build's DMG distribution with the separate Store edition.

Separate the two editions in structured data, state the live App Store availability and app ID in visible metadata, and refresh the sitemap dates. Direct-download behavior and App Store feature boundaries remain unchanged.

Test: JSON-LD validation with jq, sitemap validation with xmllint, and Apple listing verification through the Lookup API and Googlebot HTTP response (all passed).