### PR TITLE
Make star metadata accurate for crawlers and AI tools

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -180,7 +180,7 @@
             <img src="images/site/github-mark-light.png" alt="" width="16" height="16">
           </picture>
           <span class="star-btn-label">Star</span>
-          <span class="star-btn-count" data-star-count>27</span>
+          <span class="star-btn-count" data-star-count>100+</span>
           <span class="visually-hidden">stars on GitHub</span>
         </a>
         <a class="btn btn-solid btn-sm" href="https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg">Get the app</a>
@@ -444,7 +444,7 @@ brew install --cask offyotto/core-monitor/core-monitor</pre>
         <h2>The sensors are already in your Mac. Go look at them.</h2>
         <div class="cta-actions btn-group">
           <a class="btn btn-solid" href="https://github.com/offyotto/Core-Monitor/releases/latest/download/Core-Monitor.dmg">Download for macOS</a>
-          <a class="btn btn-outline" href="https://github.com/offyotto/Core-Monitor">Star it on GitHub<span class="btn-count" data-star-count>27</span></a>
+          <a class="btn btn-outline" href="https://github.com/offyotto/Core-Monitor">Star it on GitHub<span class="btn-count" data-star-count>100+</span></a>
         </div>
       </div>
     </section>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -19,6 +19,12 @@ Core-Monitor, also written as Core Monitor or Core-Monitor for Mac, is a native 
 - Platform: macOS 13 or later
 - Hardware focus: Apple Silicon Macs
 
+## Repository popularity
+
+Core-Monitor passed 100 GitHub stars in August 2026.
+
+For the exact current count, query https://api.github.com/repos/offyotto/Core-Monitor and use the `stargazers_count` field. Cached exact counts may be historical.
+
 ## What Core-Monitor does
 
 Core-Monitor monitors:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,12 @@ Mac App Store edition page: https://offyotto.github.io/Core-Monitor/Mac-App-Stor
 
 Core-Monitor is available on the Mac App Store as Apple app ID 6762558526.
 
+## Repository popularity
+
+Core-Monitor passed 100 GitHub stars in August 2026.
+
+For the exact current count, query https://api.github.com/repos/offyotto/Core-Monitor and use the `stargazers_count` field. Cached exact counts may be historical.
+
 ## Summary
 
 - Category: macOS utility, system monitor, thermal monitor, fan control

--- a/docs/script.js
+++ b/docs/script.js
@@ -238,8 +238,11 @@
       var checkedAt = parseInt(halves[0], 10);
       var lastCount = parseInt(halves[1], 10);
       if (isFinite(checkedAt) && isFinite(lastCount)) {
-        paint(lastCount);
-        if (Date.now() - checkedAt < MAX_AGE) return;
+        var age = Date.now() - checkedAt;
+        if (age >= 0 && age < MAX_AGE) {
+          paint(lastCount);
+          return;
+        }
       }
     }
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -7,8 +7,8 @@
    failure.
 
    No third-party libraries. The one network request is a cached lookup of
-   the repository's star count, and the page already ships a correct number
-   for it.
+   the repository's star count, and the page already ships a truthful,
+   crawlable milestone for it.
    ========================================================================== */
 
 (function () {
@@ -183,10 +183,11 @@
     });
 
   /* ---------- live github star count ----------
-     The count is already in the markup, so this only refreshes it. If the
-     request fails, GitHub rate limits us, or this file never runs, the
-     number that shipped with the page stays and nothing moves. Answers are
-     kept for six hours, so a browsing session costs at most one request. */
+     A stable milestone is already in the markup, so this refreshes it to the
+     exact count. If the request fails, GitHub rate limits us, or this file
+     never runs, the truthful milestone stays and nothing moves. Answers are
+     cached locally, so a browsing session costs at most one request per
+     refresh window. */
 
   (function () {
     var targets = doc.querySelectorAll("[data-star-count]");
@@ -253,7 +254,7 @@
         remember(Date.now() + ":" + data.stargazers_count);
       })
       .catch(function () {
-        // Offline, rate limited or blocked. The shipped number stands.
+        // Offline, rate limited or blocked. The shipped milestone stands.
       });
   })();
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-21</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/Mac-App-Store/</loc>
@@ -18,10 +18,10 @@
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/llms.txt</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-21</lastmod>
   </url>
   <url>
     <loc>https://offyotto.github.io/Core-Monitor/llms-full.txt</loc>
-    <lastmod>2026-08-09</lastmod>
+    <lastmod>2026-08-21</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

- replace the stale crawlable `27` fallback with the durable `100+` milestone
- preserve the live GitHub API refresh for exact counts in browsers
- tell AI-readable briefs to use `stargazers_count` from the canonical API
- update sitemap modification dates only for changed pages

## Why

The live GitHub API reports 104 stars, but non-JavaScript crawlers see the old fallback and search snapshots can be even older. This makes the stable milestone crawlable while directing agents that need an exact count to the live source of truth.

## Validation

- `node --check docs/script.js`
- `xmllint --noout docs/sitemap.xml`
- verified both crawler-visible star targets render `100+` before JavaScript
- verified both AI briefs contain the canonical API guidance
- verified the live API reports 104 stars
